### PR TITLE
(chore): bump go version to 1.25.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sigstore/model-signing
 
-go 1.25.5
+go 1.25.6
 
 require (
 	github.com/coreos/go-oidc/v3 v3.17.0


### PR DESCRIPTION
Update go version to fix vulnerebilities