### PR TITLE
(refactor): examples updated to use canonicalized version of the package

### DIFF
--- a/examples/certificate/sign/main.go
+++ b/examples/certificate/sign/main.go
@@ -1,0 +1,197 @@
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Example: Sign a model using a certificate and private key.
+//
+// This example demonstrates how to sign a model directory using a private key
+// along with a signing certificate and certificate chain. The signature includes
+// the full certificate chain for verification.
+//
+// Usage:
+//
+//	go run ./examples/certificate/sign/main.go \
+//	    --model-path=/path/to/model \
+//	    --signature-path=/path/to/model.sig \
+//	    --private-key=/path/to/private-key.pem \
+//	    --signing-cert=/path/to/signing-cert.pem \
+//	    --cert-chain=/path/to/intermediate.pem,/path/to/root.pem
+//
+// Or using environment variables:
+//
+//	export MODEL_PATH=/path/to/model
+//	export SIGNATURE_PATH=/path/to/model.sig
+//	export PRIVATE_KEY=/path/to/private-key.pem
+//	export SIGNING_CERT=/path/to/signing-cert.pem
+//	export CERT_CHAIN=/path/to/intermediate.pem,/path/to/root.pem
+//	go run ./examples/certificate/sign/main.go
+//
+// Demo mode (uses test certificates from the repository):
+//
+//	go run ./examples/certificate/sign/main.go
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sigstore/model-signing/pkg/logging"
+	certSigning "github.com/sigstore/model-signing/pkg/signing/certificate"
+)
+
+func main() {
+	// Define command-line flags
+	modelPath := flag.String("model-path", "", "Path to the model directory to sign")
+	signaturePath := flag.String("signature-path", "", "Path where the signature will be saved")
+	privateKeyPath := flag.String("private-key", "", "Path to the PEM-encoded private key")
+	signingCertPath := flag.String("signing-cert", "", "Path to the PEM-encoded signing certificate")
+	certChain := flag.String("cert-chain", "", "Comma-separated paths to certificate chain files (intermediate, root)")
+	ignoreGitPaths := flag.Bool("ignore-git-paths", true, "Ignore .git directories and .gitignore files")
+	allowSymlinks := flag.Bool("allow-symlinks", false, "Allow following symlinks in the model directory")
+	logLevel := flag.String("log-level", "debug", "Log level (debug, info, warn, error, silent)")
+	flag.Parse()
+
+	// Get values from flags or environment variables
+	if *modelPath == "" {
+		*modelPath = os.Getenv("MODEL_PATH")
+	}
+	if *signaturePath == "" {
+		*signaturePath = os.Getenv("SIGNATURE_PATH")
+	}
+	if *privateKeyPath == "" {
+		*privateKeyPath = os.Getenv("PRIVATE_KEY")
+	}
+	if *signingCertPath == "" {
+		*signingCertPath = os.Getenv("SIGNING_CERT")
+	}
+	if *certChain == "" {
+		*certChain = os.Getenv("CERT_CHAIN")
+	}
+
+	// Parse certificate chain
+	var chainPaths []string
+	if *certChain != "" {
+		chainPaths = strings.Split(*certChain, ",")
+		for i := range chainPaths {
+			chainPaths[i] = strings.TrimSpace(chainPaths[i])
+		}
+	}
+
+	// Demo mode: use test certificates and create a temporary model
+	demoMode := *modelPath == "" && *privateKeyPath == ""
+	if demoMode {
+		fmt.Println("Running in demo mode with test certificates...")
+		repoRoot := findRepoRoot()
+		certDir := filepath.Join(repoRoot, "scripts", "tests", "keys", "certificate")
+		*privateKeyPath = filepath.Join(certDir, "signing-key.pem")
+		*signingCertPath = filepath.Join(certDir, "signing-key-cert.pem")
+		chainPaths = []string{
+			filepath.Join(certDir, "int-ca-cert.pem"),
+			filepath.Join(certDir, "ca-cert.pem"),
+		}
+
+		// Create a temporary model directory
+		tmpDir, err := os.MkdirTemp("", "model-signing-cert-example-*")
+		if err != nil {
+			log.Fatalf("Failed to create temp directory: %v", err)
+		}
+		defer func() {
+			fmt.Printf("\nTo verify this signature, run:\n")
+			fmt.Printf("  go run ./examples/certificate/verify/main.go --model-path=%s --signature-path=%s --cert-chain=%s,%s\n",
+				tmpDir,
+				filepath.Join(tmpDir, "model.sig"),
+				filepath.Join(certDir, "int-ca-cert.pem"),
+				filepath.Join(certDir, "ca-cert.pem"))
+			fmt.Printf("\nNote: The demo model is at %s\n", tmpDir)
+		}()
+
+		// Create sample model files
+		if err := os.WriteFile(filepath.Join(tmpDir, "model.bin"), []byte("sample model data\n"), 0644); err != nil {
+			log.Fatalf("Failed to create model file: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), []byte(`{"version": "1.0"}`), 0644); err != nil {
+			log.Fatalf("Failed to create config file: %v", err)
+		}
+
+		*modelPath = tmpDir
+		*signaturePath = filepath.Join(tmpDir, "model.sig")
+	}
+
+	// Validate required parameters
+	if *modelPath == "" {
+		log.Fatal("--model-path is required")
+	}
+	if *signaturePath == "" {
+		log.Fatal("--signature-path is required")
+	}
+	if *privateKeyPath == "" {
+		log.Fatal("--private-key is required")
+	}
+	if *signingCertPath == "" {
+		log.Fatal("--signing-cert is required")
+	}
+
+	logger := logging.NewLoggerWithOptions(logging.LoggerOptions{
+		Level: logging.ParseLogLevel(*logLevel),
+	})
+
+	// Create signer options
+	opts := certSigning.CertificateSignerOptions{
+		ModelPath:              *modelPath,
+		SignaturePath:          *signaturePath,
+		IgnorePaths:            nil,
+		IgnoreGitPaths:         *ignoreGitPaths,
+		AllowSymlinks:          *allowSymlinks,
+		Logger:                 logger,
+		PrivateKeyPath:         *privateKeyPath,
+		SigningCertificatePath: *signingCertPath,
+		CertificateChain:       chainPaths,
+	}
+
+	// Create the signer
+	signer, err := certSigning.NewCertificateSigner(opts)
+	if err != nil {
+		log.Fatalf("Failed to create signer: %v", err)
+	}
+
+	// Sign the model
+	ctx := context.Background()
+	result, err := signer.Sign(ctx)
+	if err != nil {
+		log.Fatalf("Signing failed: %v", err)
+	}
+
+	fmt.Printf("\n%s\n", result.Message)
+}
+
+func findRepoRoot() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "."
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "."
+		}
+		dir = parent
+	}
+}

--- a/examples/certificate/verify/main.go
+++ b/examples/certificate/verify/main.go
@@ -1,0 +1,122 @@
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Example: Verify a model signature using a certificate chain.
+//
+// This example demonstrates how to verify a signed model using a certificate
+// chain. The signature must be in Sigstore bundle format with X509 certificate
+// chain verification material.
+//
+// Usage:
+//
+//	go run ./examples/certificate/verify/main.go \
+//	    --model-path=/path/to/model \
+//	    --signature-path=/path/to/model.sig \
+//	    --cert-chain=/path/to/intermediate.pem,/path/to/root.pem
+//
+// Or using environment variables:
+//
+//	export MODEL_PATH=/path/to/model
+//	export SIGNATURE_PATH=/path/to/model.sig
+//	export CERT_CHAIN=/path/to/intermediate.pem,/path/to/root.pem
+//	go run ./examples/certificate/verify/main.go
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/sigstore/model-signing/pkg/logging"
+	certVerify "github.com/sigstore/model-signing/pkg/verify/certificate"
+)
+
+func main() {
+	// Define command-line flags
+	modelPath := flag.String("model-path", "", "Path to the model directory to verify")
+	signaturePath := flag.String("signature-path", "", "Path to the signature file")
+	certChain := flag.String("cert-chain", "", "Comma-separated paths to certificate chain files (intermediate, root)")
+	ignoreGitPaths := flag.Bool("ignore-git-paths", true, "Ignore .git directories and .gitignore files")
+	allowSymlinks := flag.Bool("allow-symlinks", false, "Allow following symlinks in the model directory")
+	ignoreUnsignedFiles := flag.Bool("ignore-unsigned-files", false, "Ignore files not present in the signature")
+	logFingerprints := flag.Bool("log-fingerprints", false, "Log certificate fingerprints during verification")
+	logLevel := flag.String("log-level", "debug", "Log level (debug, info, warn, error, silent)")
+	flag.Parse()
+
+	// Get values from flags or environment variables
+	if *modelPath == "" {
+		*modelPath = os.Getenv("MODEL_PATH")
+	}
+	if *signaturePath == "" {
+		*signaturePath = os.Getenv("SIGNATURE_PATH")
+	}
+	if *certChain == "" {
+		*certChain = os.Getenv("CERT_CHAIN")
+	}
+
+	// Parse certificate chain
+	var chainPaths []string
+	if *certChain != "" {
+		chainPaths = strings.Split(*certChain, ",")
+		for i := range chainPaths {
+			chainPaths[i] = strings.TrimSpace(chainPaths[i])
+		}
+	}
+
+	// Validate required parameters
+	if *modelPath == "" {
+		log.Fatal("--model-path is required")
+	}
+	if *signaturePath == "" {
+		log.Fatal("--signature-path is required")
+	}
+	if len(chainPaths) == 0 {
+		log.Fatal("--cert-chain is required")
+	}
+
+	logger := logging.NewLoggerWithOptions(logging.LoggerOptions{
+		Level: logging.ParseLogLevel(*logLevel),
+	})
+
+	// Create verifier options
+	opts := certVerify.CertificateVerifierOptions{
+		ModelPath:           *modelPath,
+		SignaturePath:       *signaturePath,
+		IgnorePaths:         nil,
+		IgnoreGitPaths:      *ignoreGitPaths,
+		AllowSymlinks:       *allowSymlinks,
+		IgnoreUnsignedFiles: *ignoreUnsignedFiles,
+		Logger:              logger,
+		CertificateChain:    chainPaths,
+		LogFingerprints:     *logFingerprints,
+	}
+
+	// Create the verifier
+	verifier, err := certVerify.NewCertificateVerifier(opts)
+	if err != nil {
+		log.Fatalf("Failed to create verifier: %v", err)
+	}
+
+	// Verify the model
+	ctx := context.Background()
+	result, err := verifier.Verify(ctx)
+	if err != nil {
+		log.Fatalf("Verification failed: %v", err)
+	}
+
+	fmt.Printf("\n%s\n", result.Message)
+}

--- a/examples/key/sign/main.go
+++ b/examples/key/sign/main.go
@@ -1,0 +1,167 @@
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Example: Sign a model using a private key.
+//
+// This example demonstrates how to sign a model directory using an ECDSA, RSA,
+// or Ed25519 private key. The signature is saved in Sigstore bundle format.
+//
+// Usage:
+//
+//	go run ./examples/key/sign/main.go \
+//	    --model-path=/path/to/model \
+//	    --signature-path=/path/to/model.sig \
+//	    --private-key=/path/to/private-key.pem
+//
+// Or using environment variables:
+//
+//	export MODEL_PATH=/path/to/model
+//	export SIGNATURE_PATH=/path/to/model.sig
+//	export PRIVATE_KEY=/path/to/private-key.pem
+//	go run ./examples/key/sign/main.go
+//
+// Demo mode (uses test keys from the repository):
+//
+//	go run ./examples/key/sign/main.go
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/sigstore/model-signing/pkg/logging"
+	keySigning "github.com/sigstore/model-signing/pkg/signing/key"
+)
+
+func main() {
+	// Define command-line flags
+	modelPath := flag.String("model-path", "", "Path to the model directory to sign")
+	signaturePath := flag.String("signature-path", "", "Path where the signature will be saved")
+	privateKeyPath := flag.String("private-key", "", "Path to the PEM-encoded private key")
+	password := flag.String("password", "", "Password for encrypted private keys (optional)")
+	ignoreGitPaths := flag.Bool("ignore-git-paths", true, "Ignore .git directories and .gitignore files")
+	allowSymlinks := flag.Bool("allow-symlinks", false, "Allow following symlinks in the model directory")
+	logLevel := flag.String("log-level", "debug", "Log level (debug, info, warn, error, silent)")
+	flag.Parse()
+
+	// Get values from flags or environment variables
+	if *modelPath == "" {
+		*modelPath = os.Getenv("MODEL_PATH")
+	}
+	if *signaturePath == "" {
+		*signaturePath = os.Getenv("SIGNATURE_PATH")
+	}
+	if *privateKeyPath == "" {
+		*privateKeyPath = os.Getenv("PRIVATE_KEY")
+	}
+	if *password == "" {
+		*password = os.Getenv("KEY_PASSWORD")
+	}
+
+	// Demo mode: use test keys and create a temporary model
+	demoMode := *modelPath == "" && *privateKeyPath == ""
+	if demoMode {
+		fmt.Println("Running in demo mode with test keys...")
+		repoRoot := findRepoRoot()
+		*privateKeyPath = filepath.Join(repoRoot, "scripts", "tests", "keys", "certificate", "signing-key.pem")
+
+		// Create a temporary model directory
+		tmpDir, err := os.MkdirTemp("", "model-signing-example-*")
+		if err != nil {
+			log.Fatalf("Failed to create temp directory: %v", err)
+		}
+		defer func() {
+			fmt.Printf("\nTo verify this signature, run:\n")
+			fmt.Printf("  go run ./examples/key/verify/main.go --model-path=%s --signature-path=%s --public-key=%s\n",
+				tmpDir,
+				filepath.Join(tmpDir, "model.sig"),
+				filepath.Join(repoRoot, "scripts", "tests", "keys", "certificate", "signing-key-pub.pem"))
+			fmt.Printf("\nNote: The demo model is at %s (will be cleaned up on exit in non-demo mode)\n", tmpDir)
+		}()
+
+		// Create sample model files
+		if err := os.WriteFile(filepath.Join(tmpDir, "model.bin"), []byte("sample model data\n"), 0644); err != nil {
+			log.Fatalf("Failed to create model file: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), []byte(`{"version": "1.0"}`), 0644); err != nil {
+			log.Fatalf("Failed to create config file: %v", err)
+		}
+
+		*modelPath = tmpDir
+		*signaturePath = filepath.Join(tmpDir, "model.sig")
+	}
+
+	// Validate required parameters
+	if *modelPath == "" {
+		log.Fatal("--model-path is required")
+	}
+	if *signaturePath == "" {
+		log.Fatal("--signature-path is required")
+	}
+	if *privateKeyPath == "" {
+		log.Fatal("--private-key is required")
+	}
+
+	logger := logging.NewLoggerWithOptions(logging.LoggerOptions{
+		Level: logging.ParseLogLevel(*logLevel),
+	})
+
+	// Create signer options
+	opts := keySigning.KeySignerOptions{
+		ModelPath:      *modelPath,
+		SignaturePath:  *signaturePath,
+		IgnorePaths:    nil,
+		IgnoreGitPaths: *ignoreGitPaths,
+		AllowSymlinks:  *allowSymlinks,
+		Logger:         logger,
+		PrivateKeyPath: *privateKeyPath,
+		Password:       *password,
+	}
+
+	// Create the signer
+	signer, err := keySigning.NewKeySigner(opts)
+	if err != nil {
+		log.Fatalf("Failed to create signer: %v", err)
+	}
+
+	// Sign the model
+	ctx := context.Background()
+	result, err := signer.Sign(ctx)
+	if err != nil {
+		log.Fatalf("Signing failed: %v", err)
+	}
+
+	fmt.Printf("\n%s\n", result.Message)
+}
+
+func findRepoRoot() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "."
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "."
+		}
+		dir = parent
+	}
+}

--- a/examples/key/verify/main.go
+++ b/examples/key/verify/main.go
@@ -1,0 +1,109 @@
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Example: Verify a model signature using a public key.
+//
+// This example demonstrates how to verify a signed model using an ECDSA, RSA,
+// or Ed25519 public key. The signature must be in Sigstore bundle format.
+//
+// Usage:
+//
+//	go run ./examples/key/verify/main.go \
+//	    --model-path=/path/to/model \
+//	    --signature-path=/path/to/model.sig \
+//	    --public-key=/path/to/public-key.pem
+//
+// Or using environment variables:
+//
+//	export MODEL_PATH=/path/to/model
+//	export SIGNATURE_PATH=/path/to/model.sig
+//	export PUBLIC_KEY=/path/to/public-key.pem
+//	go run ./examples/key/verify/main.go
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/sigstore/model-signing/pkg/logging"
+	keyVerify "github.com/sigstore/model-signing/pkg/verify/key"
+)
+
+func main() {
+	// Define command-line flags
+	modelPath := flag.String("model-path", "", "Path to the model directory to verify")
+	signaturePath := flag.String("signature-path", "", "Path to the signature file")
+	publicKeyPath := flag.String("public-key", "", "Path to the PEM-encoded public key")
+	ignoreGitPaths := flag.Bool("ignore-git-paths", true, "Ignore .git directories and .gitignore files")
+	allowSymlinks := flag.Bool("allow-symlinks", false, "Allow following symlinks in the model directory")
+	ignoreUnsignedFiles := flag.Bool("ignore-unsigned-files", false, "Ignore files not present in the signature")
+	logLevel := flag.String("log-level", "debug", "Log level (debug, info, warn, error, silent)")
+	flag.Parse()
+
+	// Get values from flags or environment variables
+	if *modelPath == "" {
+		*modelPath = os.Getenv("MODEL_PATH")
+	}
+	if *signaturePath == "" {
+		*signaturePath = os.Getenv("SIGNATURE_PATH")
+	}
+	if *publicKeyPath == "" {
+		*publicKeyPath = os.Getenv("PUBLIC_KEY")
+	}
+
+	// Validate required parameters
+	if *modelPath == "" {
+		log.Fatal("--model-path is required")
+	}
+	if *signaturePath == "" {
+		log.Fatal("--signature-path is required")
+	}
+	if *publicKeyPath == "" {
+		log.Fatal("--public-key is required")
+	}
+
+	logger := logging.NewLoggerWithOptions(logging.LoggerOptions{
+		Level: logging.ParseLogLevel(*logLevel),
+	})
+
+	// Create verifier options
+	opts := keyVerify.KeyVerifierOptions{
+		ModelPath:           *modelPath,
+		SignaturePath:       *signaturePath,
+		IgnorePaths:         nil,
+		IgnoreGitPaths:      *ignoreGitPaths,
+		AllowSymlinks:       *allowSymlinks,
+		IgnoreUnsignedFiles: *ignoreUnsignedFiles,
+		Logger:              logger,
+		PublicKeyPath:       *publicKeyPath,
+	}
+
+	// Create the verifier
+	verifier, err := keyVerify.NewKeyVerifier(opts)
+	if err != nil {
+		log.Fatalf("Failed to create verifier: %v", err)
+	}
+
+	// Verify the model
+	ctx := context.Background()
+	result, err := verifier.Verify(ctx)
+	if err != nil {
+		log.Fatalf("Verification failed: %v", err)
+	}
+
+	fmt.Printf("\n%s\n", result.Message)
+}

--- a/examples/sigstore/sign/main.go
+++ b/examples/sigstore/sign/main.go
@@ -1,0 +1,151 @@
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Example: Sign a model using Sigstore (keyless signing).
+//
+// This example demonstrates how to sign a model directory using Sigstore's
+// keyless signing infrastructure. Sigstore uses OIDC for identity verification
+// and records signatures in a transparency log.
+//
+// Authentication methods (in order of precedence):
+//  1. SIGSTORE_ID_TOKEN environment variable (explicit OIDC token)
+//  2. ACTIONS_ID_TOKEN_REQUEST_TOKEN (GitHub Actions ambient credentials)
+//  3. Interactive OAuth flow (browser-based authentication)
+//
+// Usage:
+//
+//	go run ./examples/sigstore/sign/main.go \
+//	    --model-path=/path/to/model \
+//	    --signature-path=/path/to/model.sig
+//
+// With explicit OIDC token:
+//
+//	export SIGSTORE_ID_TOKEN='<your-oidc-token>'
+//	go run ./examples/sigstore/sign/main.go \
+//	    --model-path=/path/to/model \
+//	    --signature-path=/path/to/model.sig \
+//	    --use-ambient-credentials
+//
+// For testing (uses Sigstore staging infrastructure):
+//
+//	go run ./examples/sigstore/sign/main.go \
+//	    --model-path=/path/to/model \
+//	    --signature-path=/path/to/model.sig \
+//	    --staging
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/sigstore/model-signing/pkg/logging"
+	sigstoreSigning "github.com/sigstore/model-signing/pkg/signing/sigstore"
+)
+
+func main() {
+	// Define command-line flags
+	modelPath := flag.String("model-path", "", "Path to the model directory to sign")
+	signaturePath := flag.String("signature-path", "", "Path where the signature will be saved")
+	useStaging := flag.Bool("staging", false, "Use Sigstore staging infrastructure (for testing)")
+	useAmbientCredentials := flag.Bool("use-ambient-credentials", false, "Use ambient OIDC credentials (e.g., from SIGSTORE_ID_TOKEN)")
+	ignoreGitPaths := flag.Bool("ignore-git-paths", true, "Ignore .git directories and .gitignore files")
+	allowSymlinks := flag.Bool("allow-symlinks", false, "Allow following symlinks in the model directory")
+	logLevel := flag.String("log-level", "debug", "Log level (debug, info, warn, error, silent)")
+	flag.Parse()
+
+	// Get values from flags or environment variables
+	if *modelPath == "" {
+		*modelPath = os.Getenv("MODEL_PATH")
+	}
+	if *signaturePath == "" {
+		*signaturePath = os.Getenv("SIGNATURE_PATH")
+	}
+
+	// Demo mode: create a temporary model
+	demoMode := *modelPath == ""
+	if demoMode {
+		fmt.Println("Running in demo mode...")
+
+		// Create a temporary model directory
+		tmpDir, err := os.MkdirTemp("", "model-signing-sigstore-example-*")
+		if err != nil {
+			log.Fatalf("Failed to create temp directory: %v", err)
+		}
+
+		// Create sample model files
+		if err := os.WriteFile(filepath.Join(tmpDir, "model.bin"), []byte("sample model data\n"), 0644); err != nil {
+			log.Fatalf("Failed to create model file: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), []byte(`{"version": "1.0"}`), 0644); err != nil {
+			log.Fatalf("Failed to create config file: %v", err)
+		}
+
+		*modelPath = tmpDir
+		*signaturePath = filepath.Join(tmpDir, "model.sig")
+		*useStaging = true // Default to staging for demo mode
+
+		defer func() {
+			fmt.Printf("\nTo verify this signature, run:\n")
+			fmt.Printf("  go run ./examples/sigstore/verify/main.go --model-path=%s --signature-path=%s --staging --identity=<your-email> --identity-provider=<oidc-provider>\n",
+				tmpDir,
+				filepath.Join(tmpDir, "model.sig"))
+			fmt.Printf("\nNote: Replace <your-email> with the identity from your OIDC token\n")
+			fmt.Printf("      Replace <oidc-provider> with your OIDC provider URL\n")
+			fmt.Printf("      The demo model is at %s\n", tmpDir)
+		}()
+	}
+
+	// Validate required parameters
+	if *modelPath == "" {
+		log.Fatal("--model-path is required")
+	}
+	if *signaturePath == "" {
+		log.Fatal("--signature-path is required")
+	}
+
+	logger := logging.NewLoggerWithOptions(logging.LoggerOptions{
+		Level: logging.ParseLogLevel(*logLevel),
+	})
+
+	// Create signer options
+	opts := sigstoreSigning.SigstoreSignerOptions{
+		ModelPath:             *modelPath,
+		SignaturePath:         *signaturePath,
+		IgnorePaths:           nil,
+		IgnoreGitPaths:        *ignoreGitPaths,
+		AllowSymlinks:         *allowSymlinks,
+		Logger:                logger,
+		UseStaging:            *useStaging,
+		UseAmbientCredentials: *useAmbientCredentials,
+	}
+
+	// Create the signer
+	signer, err := sigstoreSigning.NewSigstoreSigner(opts)
+	if err != nil {
+		log.Fatalf("Failed to create signer: %v", err)
+	}
+
+	// Sign the model
+	ctx := context.Background()
+	result, err := signer.Sign(ctx)
+	if err != nil {
+		log.Fatalf("Signing failed: %v\n\nHint: Set SIGSTORE_ID_TOKEN environment variable or run without --use-ambient-credentials for interactive OAuth", err)
+	}
+
+	fmt.Printf("\n%s\n", result.Message)
+}

--- a/examples/sigstore/verify/main.go
+++ b/examples/sigstore/verify/main.go
@@ -1,0 +1,128 @@
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Example: Verify a model signature using Sigstore.
+//
+// This example demonstrates how to verify a model signed with Sigstore's
+// keyless signing infrastructure. Verification requires specifying the
+// expected signer identity and OIDC identity provider.
+//
+// Usage:
+//
+//	go run ./examples/sigstore/verify/main.go \
+//	    --model-path=/path/to/model \
+//	    --signature-path=/path/to/model.sig \
+//	    --identity=signer@example.com \
+//	    --identity-provider=https://accounts.google.com
+//
+// For signatures created with staging infrastructure:
+//
+//	go run ./examples/sigstore/verify/main.go \
+//	    --model-path=/path/to/model \
+//	    --signature-path=/path/to/model.sig \
+//	    --identity=signer@example.com \
+//	    --identity-provider=https://accounts.google.com \
+//	    --staging
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/sigstore/model-signing/pkg/logging"
+	sigstoreVerify "github.com/sigstore/model-signing/pkg/verify/sigstore"
+)
+
+func main() {
+	// Define command-line flags
+	modelPath := flag.String("model-path", "", "Path to the model directory to verify")
+	signaturePath := flag.String("signature-path", "", "Path to the signature file")
+	identity := flag.String("identity", "", "Expected signer identity (e.g., email address)")
+	identityProvider := flag.String("identity-provider", "", "Expected OIDC identity provider URL (e.g., https://accounts.google.com)")
+	useStaging := flag.Bool("staging", false, "Use Sigstore staging infrastructure (for testing)")
+	trustRootPath := flag.String("trust-root", "", "Path to custom trust root JSON file (optional)")
+	ignoreGitPaths := flag.Bool("ignore-git-paths", true, "Ignore .git directories and .gitignore files")
+	allowSymlinks := flag.Bool("allow-symlinks", false, "Allow following symlinks in the model directory")
+	ignoreUnsignedFiles := flag.Bool("ignore-unsigned-files", false, "Ignore files not present in the signature")
+	logLevel := flag.String("log-level", "debug", "Log level (debug, info, warn, error, silent)")
+	flag.Parse()
+
+	// Get values from flags or environment variables
+	if *modelPath == "" {
+		*modelPath = os.Getenv("MODEL_PATH")
+	}
+	if *signaturePath == "" {
+		*signaturePath = os.Getenv("SIGNATURE_PATH")
+	}
+	if *identity == "" {
+		*identity = os.Getenv("SIGNER_IDENTITY")
+	}
+	if *identityProvider == "" {
+		*identityProvider = os.Getenv("IDENTITY_PROVIDER")
+	}
+	if *trustRootPath == "" {
+		*trustRootPath = os.Getenv("TRUST_CONFIG")
+	}
+
+	// Validate required parameters
+	if *modelPath == "" {
+		log.Fatal("--model-path is required")
+	}
+	if *signaturePath == "" {
+		log.Fatal("--signature-path is required")
+	}
+	if *identity == "" {
+		log.Fatal("--identity is required (the expected signer identity, e.g., email)")
+	}
+	if *identityProvider == "" {
+		log.Fatal("--identity-provider is required (the expected OIDC identity provider URL)")
+	}
+
+	logger := logging.NewLoggerWithOptions(logging.LoggerOptions{
+		Level: logging.ParseLogLevel(*logLevel),
+	})
+
+	// Create verifier options
+	opts := sigstoreVerify.SigstoreVerifierOptions{
+		ModelPath:           *modelPath,
+		SignaturePath:       *signaturePath,
+		IgnorePaths:         nil,
+		IgnoreGitPaths:      *ignoreGitPaths,
+		AllowSymlinks:       *allowSymlinks,
+		IgnoreUnsignedFiles: *ignoreUnsignedFiles,
+		Logger:              logger,
+		Identity:            *identity,
+		IdentityProvider:    *identityProvider,
+		UseStaging:          *useStaging,
+		TrustConfigPath:     *trustRootPath,
+	}
+
+	// Create the verifier
+	verifier, err := sigstoreVerify.NewSigstoreVerifier(opts)
+	if err != nil {
+		log.Fatalf("Failed to create verifier: %v", err)
+	}
+
+	// Verify the model
+	ctx := context.Background()
+	result, err := verifier.Verify(ctx)
+	if err != nil {
+		log.Fatalf("Verification failed: %v", err)
+	}
+
+	fmt.Printf("\n%s\n", result.Message)
+}


### PR DESCRIPTION
<!-- Thanks for opening a pull request! Please do not just delete this text. -->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?

Please remember to:
- Pair the PR with an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->
This PR consists of updated examples, on using the canonicalized version of the package.

##### Checklist

- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code has docstrings and type annotations
- [ ] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [ ] Public facing changes are paired with documentation changes
- [ ] Release note has been added to CHANGELOG.md if needed

<!--
Add a release note for each of the following conditions in CHANGELOG.md:

* Model signature changes (additions, deletions, updates)
* API additions: new functions, new arguments, new supported signing methods, etc.
* Anything noteworthy to an administrator using model-signing package (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

Use past-tense.

-->
