### PR TITLE
(ci): rely on Makefile for gh workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,4 +34,4 @@ jobs:
           check-latest: true
 
       - name: Build
-        run: go build -v ./cmd/model-signing
+        run: make build

--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -45,7 +45,7 @@ jobs:
           check-latest: true
 
       - name: Build model-signing binary
-        run: go build -o scripts/tests/model-signing ./cmd/model-signing
+        run: make build-test-binary
 
       - name: Run CLI tests
         run: ./scripts/tests/testrunner
@@ -70,7 +70,7 @@ jobs:
           python-version: '3.12'
 
       - name: Build model-signing binary
-        run: go build -o scripts/tests/model-signing ./cmd/model-signing
+        run: make build-test-binary
 
       - name: Run interoperability tests
         run: ./scripts/tests/test-interoperability.sh
@@ -91,7 +91,7 @@ jobs:
           check-latest: true
 
       - name: Build model-signing binary
-        run: go build -o scripts/tests/model-signing ./cmd/model-signing
+        run: make build-test-binary
 
       - name: Run hardening tests
         run: ./scripts/tests/test-hardening.sh

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -28,8 +28,5 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Build container image
-        run: docker build -t model-signing:test -f Containerfile .
-
-      - name: Verify container runs
-        run: docker run --rm model-signing:test --help
+      - name: Build and verify container
+        run: make container-build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,11 +38,8 @@ jobs:
           go-version-file: './go.mod'
           check-latest: true
 
-      - name: Install doc2go
-        run: go install go.abhg.dev/doc2go@latest
-
       - name: Generate documentation
-        run: doc2go -out ./html ./...
+        run: make docs
 
       - name: Upload docs artifact
         if: github.event_name == 'push'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -64,13 +64,7 @@ jobs:
           check-latest: true
 
       - name: Check formatting
-        run: |
-          UNFORMATTED=$(find . -name '*.go' -not -path './examples/*' | xargs gofmt -l)
-          if [ -n "$UNFORMATTED" ]; then
-            echo "::error::The following files are not formatted correctly:"
-            echo "$UNFORMATTED"
-            exit 1
-          fi
+        run: make fmt-check
 
   go-mod-tidy:
     name: Go mod tidy check
@@ -88,10 +82,4 @@ jobs:
           check-latest: true
 
       - name: Check go mod tidy
-        run: |
-          go mod tidy
-          if ! git diff --quiet go.mod go.sum; then
-            echo "::error::go.mod or go.sum is not tidy. Please run 'go mod tidy'."
-            git diff go.mod go.sum
-            exit 1
-          fi
+        run: make mod-tidy-check

--- a/.github/workflows/oci-manifest-tests.yml
+++ b/.github/workflows/oci-manifest-tests.yml
@@ -50,7 +50,7 @@ jobs:
           python-version: '3.12'
 
       - name: Build model-signing binary
-        run: go build -o scripts/tests/model-signing ./cmd/model-signing
+        run: make build-test-binary
 
       - name: Run OCI manifest tests
         run: ./scripts/tests/test-oci-manifest.sh

--- a/.github/workflows/otel-tests.yml
+++ b/.github/workflows/otel-tests.yml
@@ -51,7 +51,7 @@ jobs:
           check-latest: true
 
       - name: Build model-signing binary with OTel
-        run: go build -tags=otel -o scripts/tests/model-signing ./cmd/model-signing
+        run: make build-test-binary-otel
 
       - name: Wait for Jaeger readiness
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -34,7 +34,7 @@ jobs:
           check-latest: true
 
       - name: Run tests
-        run: go test -v -race -coverprofile=coverage.out -covermode=atomic ./cmd/... ./pkg/...
+        run: make test-ci
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2

--- a/.github/workflows/verify_license.yml
+++ b/.github/workflows/verify_license.yml
@@ -31,9 +31,5 @@ jobs:
         with:
           go-version-file: './go.mod'
           check-latest: true
-      - name: Install addlicense
-        run: go install github.com/google/addlicense@v1.1.1
       - name: Check license headers
-        run: |
-          set -e
-          addlicense -check -l apache -c 'The Sigstore Authors' -ignore "third_party/**" -ignore "**/*.sh" -v *
+        run: make license-check


### PR DESCRIPTION
<!-- Thanks for opening a pull request! Please do not just delete this text. -->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?

Please remember to:
- Pair the PR with an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->
This PR addresses:
Enforcing the use of Makefile and it's commands for Github Workflows stage level triggers rather than embedding similar commands throughout different workflows

##### Checklist

- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code has docstrings and type annotations
- [ ] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [ ] Public facing changes are paired with documentation changes
- [ ] Release note has been added to CHANGELOG.md if needed

<!--
Add a release note for each of the following conditions in CHANGELOG.md:

* Model signature changes (additions, deletions, updates)
* API additions: new functions, new arguments, new supported signing methods, etc.
* Anything noteworthy to an administrator using model-signing package (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

Use past-tense.

-->
