### PR TITLE
feat: add max workers and chunk size in adapter

### DIFF
--- a/test/conformance/benchmark.go
+++ b/test/conformance/benchmark.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"os"
 	"time"
-
-	"github.com/sigstore/model-signing/pkg/modelartifact"
 )
 
 func benchmarkModel(args []string) int {
@@ -38,6 +36,8 @@ func benchmarkModel(args []string) int {
 	warmup := fs.Int("warmup", 1, "Number of warmup iterations before timed loop")
 	hashAlgorithm := fs.String("hash-algorithm", "", "Hash algorithm: sha256|blake2b (sign and hash operations)")
 	shardSize := fs.Int64("shard-size", 0, "Shard size in bytes for shard serialization (sign and hash operations; 0 = file serialization)")
+	chunkSize := fs.Int("chunk-size", -1, "Read chunk size in bytes (hash operation; 0 = read file whole, -1 = library default 8KB)")
+	maxWorkers := fs.Int("max-workers", 0, "Number of parallel hashing workers (hash operation; 0 = sequential)")
 	var certChain stringSlice
 	fs.Var(&certChain, "cert-chain", "Certificate chain PEM (verify, certificate method; repeat for multiple)")
 
@@ -55,15 +55,7 @@ func benchmarkModel(args []string) int {
 
 	if *operation == "hash" {
 		doOnce = func() int {
-			_, err := modelartifact.Canonicalize(*modelPath, modelartifact.Options{
-				HashAlgorithm: *hashAlgorithm,
-				ShardSize:     *shardSize,
-			})
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "canonicalize error: %v\n", err)
-				return 1
-			}
-			return 0
+			return hashModel(*modelPath, *hashAlgorithm, *shardSize, *chunkSize, *maxWorkers)
 		}
 	} else {
 		switch *method {

--- a/test/conformance/capabilities.go
+++ b/test/conformance/capabilities.go
@@ -22,7 +22,7 @@ import (
 func printCapabilities() int {
 	caps := map[string]any{
 		"protocol_version": 1,
-		"flags":            []string{"--hash-algorithm", "--shard-size"},
+		"flags":            []string{"--hash-algorithm", "--shard-size", "--chunk-size", "--max-workers"},
 		"hash_algorithms":  []string{"sha256", "blake2b"},
 		"benchmark_model":  true,
 	}

--- a/test/conformance/hash.go
+++ b/test/conformance/hash.go
@@ -1,0 +1,152 @@
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/sigstore/model-signing/pkg/config"
+	"github.com/sigstore/model-signing/pkg/modelartifact"
+	"github.com/sigstore/model-signing/pkg/utils"
+)
+
+// hashModel runs canonicalization with optional chunk size and worker count overrides.
+//
+// chunkSize < 0 and maxWorkers <= 1: delegates to modelartifact.Canonicalize.
+// chunkSize >= 0: builds a HashingConfig directly to access SetChunkSize.
+// maxWorkers > 1: partitions files across goroutines for parallel hashing.
+func hashModel(modelPath, hashAlgorithm string, shardSize int64, chunkSize int, maxWorkers int) int {
+	if maxWorkers > 1 {
+		return hashModelParallel(modelPath, hashAlgorithm, shardSize, chunkSize, maxWorkers)
+	}
+
+	if chunkSize >= 0 {
+		hc := buildHashingConfigWithChunk(hashAlgorithm, shardSize, chunkSize, nil)
+		_, err := hc.Hash(modelPath, nil)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "canonicalize error: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+
+	_, err := modelartifact.Canonicalize(modelPath, modelartifact.Options{
+		HashAlgorithm: hashAlgorithm,
+		ShardSize:     shardSize,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "canonicalize error: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+// hashModelParallel hashes a model directory using multiple goroutines.
+//
+// The Go library's HashingConfig.Hash() is sequential. This function provides
+// adapter-level parallelism by partitioning the file list across workers,
+// each calling Hash() with its subset. HashingConfig is read-only during
+// hashing so a single instance is shared safely across goroutines.
+func hashModelParallel(modelPath, hashAlgorithm string, shardSize int64, chunkSize int, maxWorkers int) int {
+	absModelPath, err := filepath.Abs(modelPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "canonicalize error: %v\n", err)
+		return 1
+	}
+
+	files, err := walkFiles(absModelPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "walk error: %v\n", err)
+		return 1
+	}
+
+	if len(files) == 0 {
+		return 0
+	}
+
+	hc := buildHashingConfigWithChunk(hashAlgorithm, shardSize, chunkSize, nil)
+	partitions := partitionFiles(files, maxWorkers)
+
+	var wg sync.WaitGroup
+	errs := make([]error, len(partitions))
+
+	for i, partition := range partitions {
+		wg.Add(1)
+		go func(idx int, subset []string) {
+			defer wg.Done()
+			_, errs[idx] = hc.Hash(absModelPath, subset)
+		}(i, partition)
+	}
+	wg.Wait()
+
+	for _, e := range errs {
+		if e != nil {
+			fmt.Fprintf(os.Stderr, "canonicalize error: %v\n", e)
+			return 1
+		}
+	}
+	return 0
+}
+
+// walkFiles collects all regular file paths under a directory.
+func walkFiles(root string) ([]string, error) {
+	var files []string
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			files = append(files, path)
+		}
+		return nil
+	})
+	return files, err
+}
+
+// partitionFiles distributes files round-robin across n buckets.
+func partitionFiles(files []string, n int) [][]string {
+	if n > len(files) {
+		n = len(files)
+	}
+	parts := make([][]string, n)
+	for i, f := range files {
+		parts[i%n] = append(parts[i%n], f)
+	}
+	return parts
+}
+
+// buildHashingConfigWithChunk creates a HashingConfig with explicit chunk size.
+// This bypasses modelartifact.Canonicalize to access config.SetChunkSize,
+// which is not exposed through modelartifact.Options.
+func buildHashingConfigWithChunk(hashAlgorithm string, shardSize int64, chunkSize int, ignorePaths []string) *config.HashingConfig {
+	algo := hashAlgorithm
+	if algo == "" {
+		algo = utils.DefaultHashAlgorithm
+	}
+
+	hc := config.NewHashingConfig()
+	if shardSize > 0 {
+		hc.UseShardSerialization(algo, shardSize, false, ignorePaths)
+	} else {
+		hc.UseFileSerialization(algo, false, ignorePaths)
+	}
+	if chunkSize >= 0 {
+		hc.SetChunkSize(chunkSize)
+	}
+	return hc
+}


### PR DESCRIPTION
<!-- Thanks for opening a pull request! Please do not just delete this text. -->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?

Please remember to:
- Pair the PR with an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->
Addresses: 
- https://github.com/sampras343/model-transparency-go/issues/87
- https://github.com/sampras343/model-transparency-go/issues/88

##### Checklist

- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code has docstrings and type annotations
- [ ] All new code is covered by tests. Aim for at least 90% coverage. CI is configured to highlight lines not covered by tests.
- [ ] Public facing changes are paired with documentation changes
- [ ] Release note has been added to CHANGELOG.md if needed

<!--
Add a release note for each of the following conditions in CHANGELOG.md:

* Model signature changes (additions, deletions, updates)
* API additions: new functions, new arguments, new supported signing methods, etc.
* Anything noteworthy to an administrator using model-signing package (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

Use past-tense.

-->
