### PR TITLE
Migrate conformance test token from GitHub beacon to GCS

### DIFF
--- a/.github/workflows/cross-os.yml
+++ b/.github/workflows/cross-os.yml
@@ -79,8 +79,8 @@ jobs:
           check-latest: true
       - name: Build model-signing CLI
         run: go build -v -o model-signing${{ matrix.os == 'windows-latest' && '.exe' || '' }} ./cmd/model-signing
-      - name: store beacon token into oidc-token.txt
-        uses: sigstore-conformance/extremely-dangerous-public-oidc-beacon@977e8d08554ca9bda279c96e91be2119fb67c730 # main
+      - name: Fetch conformance testing OIDC token
+        run: curl --fail --retry 3 --output oidc-token.txt https://storage.googleapis.com/sigstore-conformance-testing-token/untrusted-testing-token.txt
       - name: Sign the model
         run: ./model-signing${{ matrix.os == 'windows-latest' && '.exe' || '' }} sign sigstore "$(pwd)/model_root" --use-staging --signature "$(pwd)/model.sig" --identity-token $(cat oidc-token.txt)
       - name: upload model signature
@@ -147,5 +147,5 @@ jobs:
       - name: Verify the model
         run: |
           ./model-signing${{ matrix.os == 'windows-latest' && '.exe' || '' }} verify sigstore "$(pwd)/model_root" --use-staging --signature "$(pwd)/model.sig" \
-            --identity "https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/.github/workflows/extremely-dangerous-oidc-beacon.yml@refs/heads/main" \
-            --identity-provider "https://token.actions.githubusercontent.com"
+            --identity "untrusted-sa@sigstore-conformance.iam.gserviceaccount.com" \
+            --identity-provider "https://accounts.google.com"

--- a/scripts/tests/functions
+++ b/scripts/tests/functions
@@ -1,13 +1,15 @@
 
-# Fetch an OIDC token from the sigstore-conformance beacon with expiry validation.
-# Re-fetches if the token has insufficient remaining lifetime. The beacon refreshes
-# tokens on a ~10 min cron cycle, so we use a timeout-based approach to span at
-# least one full refresh cycle.
-# Args: $1=clone_dir  $2=token_file  [$3=timeout_secs]  [$4=min_lifetime_secs]
+# URL of the conformance testing OIDC token (published by a Google Cloud Run
+# service, refreshed every 15 minutes, valid for > 45 minutes).
+CONFORMANCE_TOKEN_URL="https://storage.googleapis.com/sigstore-conformance-testing-token/untrusted-testing-token.txt"
+
+# Fetch an OIDC token from the sigstore-conformance GCS bucket with expiry
+# validation.  Re-fetches if the token has insufficient remaining lifetime.
+# Args: $1=token_dir  $2=token_file  [$3=timeout_secs]  [$4=min_lifetime_secs]
 fetch_oidc_token() {
 	local tokenproj="$1"
 	local token_file="$2"
-	local timeout="${3:-600}"       # 10 minutes — covers one full beacon refresh cycle
+	local timeout="${3:-120}"
 	local min_lifetime="${4:-30}"
 	local start_time attempt
 	start_time=$(date +%s)
@@ -24,19 +26,17 @@ fetch_oidc_token() {
 			return 1
 		fi
 
-		rm -rf "${tokenproj}"
 		mkdir -p "${tokenproj}"
 
-		if ! git clone --quiet --single-branch --branch current-token --depth 1 \
-			https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon \
-			"${tokenproj}" 2>/dev/null; then
-			echo "  Warning: git clone failed (attempt ${attempt}, ${elapsed}s elapsed)"
+		if ! curl --fail --silent --retry 3 --output "${token_file}" \
+			"${CONFORMANCE_TOKEN_URL}" 2>/dev/null; then
+			echo "  Warning: token download failed (attempt ${attempt}, ${elapsed}s elapsed)"
 			sleep 10
 			continue
 		fi
 
-		if [ ! -f "${token_file}" ]; then
-			echo "  Warning: token file not found (attempt ${attempt}, ${elapsed}s elapsed)"
+		if [ ! -s "${token_file}" ]; then
+			echo "  Warning: token file is empty (attempt ${attempt}, ${elapsed}s elapsed)"
 			sleep 10
 			continue
 		fi
@@ -64,7 +64,7 @@ fetch_oidc_token() {
 			return 0
 		fi
 
-		sleep 30   # wait for beacon to mint a fresh token
+		sleep 30
 	done
 }
 

--- a/scripts/tests/test-interoperability.sh
+++ b/scripts/tests/test-interoperability.sh
@@ -329,8 +329,8 @@ echo
 # --- Sigstore method ---
 echo "[Go->Python] Testing 'sigstore' method"
 
-SIGSTORE_IDENTITY="https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/.github/workflows/extremely-dangerous-oidc-beacon.yml@refs/heads/main"
-SIGSTORE_ISSUER="https://token.actions.githubusercontent.com"
+SIGSTORE_IDENTITY="untrusted-sa@sigstore-conformance.iam.gserviceaccount.com"
+SIGSTORE_ISSUER="https://accounts.google.com"
 
 echo "  Go: Signing with sigstore (with OIDC token retry)..."
 if ! sigstore_sign_with_retry "${TOKENPROJ}" "${TOKEN_FILE}" "--identity-token" \

--- a/scripts/tests/test-oci-manifest.sh
+++ b/scripts/tests/test-oci-manifest.sh
@@ -223,8 +223,8 @@ TOKENPROJ="${TMPDIR}/tokenproj"
 mkdir -p "${TOKENPROJ}"
 token_file="${TOKENPROJ}/oidc-token.txt"
 
-SIGSTORE_IDENTITY="https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/.github/workflows/extremely-dangerous-oidc-beacon.yml@refs/heads/main"
-SIGSTORE_ISSUER="https://token.actions.githubusercontent.com"
+SIGSTORE_IDENTITY="untrusted-sa@sigstore-conformance.iam.gserviceaccount.com"
+SIGSTORE_ISSUER="https://accounts.google.com"
 
 echo
 echo "=== SIGSTORE strategy: cross-verification tests ==="

--- a/scripts/tests/test-otel.sh
+++ b/scripts/tests/test-otel.sh
@@ -178,8 +178,8 @@ SIGSTORE_SIGFILE="${TMPDIR}/sigstore-method.sig"
 TOKENPROJ="${TMPDIR}/tokenproj"
 TOKEN_FILE="${TOKENPROJ}/oidc-token.txt"
 
-SIGSTORE_IDENTITY="https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/.github/workflows/extremely-dangerous-oidc-beacon.yml@refs/heads/main"
-SIGSTORE_ISSUER="https://token.actions.githubusercontent.com"
+SIGSTORE_IDENTITY="untrusted-sa@sigstore-conformance.iam.gserviceaccount.com"
+SIGSTORE_ISSUER="https://accounts.google.com"
 
 echo "[Sigstore] Signing model (with OIDC token retry)..."
 if ! sigstore_sign_with_retry "${TOKENPROJ}" "${TOKEN_FILE}" "--identity-token" \

--- a/scripts/tests/test-sign-verify-allversions.sh
+++ b/scripts/tests/test-sign-verify-allversions.sh
@@ -125,8 +125,8 @@ if ! out=$(${DIR}/model-signing \
 	verify sigstore \
 	--use-staging \
 	--signature "${sigfile_sigstore}" \
-	--identity https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/.github/workflows/extremely-dangerous-oidc-beacon.yml@refs/heads/main \
-	--identity-provider https://token.actions.githubusercontent.com \
+	--identity untrusted-sa@sigstore-conformance.iam.gserviceaccount.com \
+	--identity-provider https://accounts.google.com \
 	--ignore-paths "${ignorefile}" \
 	"${MODELDIR}" 2>&1); then
 	echo "Error: 'verify sigstore' failed"


### PR DESCRIPTION
## Summary

- Replace the deprecated `extremely-dangerous-public-oidc-beacon` GitHub Action with a `curl` fetch from the new GCS-hosted conformance token
- Update all test identity/issuer references to the new Google service account
- Simplify `fetch_oidc_token()` in test scripts from git-clone to curl (reduces timeout from 600s to 120s)

The old beacon was unreliable due to GitHub Actions scheduling being best-effort, causing expired tokens that blocked CI. The new token is published by a Google Cloud Run service every 15 minutes and is valid for > 45 minutes.

**New token details:**
- URL: `https://storage.googleapis.com/sigstore-conformance-testing-token/untrusted-testing-token.txt`
- Issuer: `https://accounts.google.com`
- Identity: `untrusted-sa@sigstore-conformance.iam.gserviceaccount.com`

## Files changed

- `.github/workflows/cross-os.yml` — replaced beacon action with curl, updated verify identity/issuer
- `scripts/tests/functions` — rewrote `fetch_oidc_token()` to use GCS
- `scripts/tests/test-interoperability.sh` — updated identity/issuer
- `scripts/tests/test-oci-manifest.sh` — updated identity/issuer
- `scripts/tests/test-otel.sh` — updated identity/issuer
- `scripts/tests/test-sign-verify-allversions.sh` — updated identity/issuer

## Test plan

- [ ] Verify cross-OS workflow passes with the new token source
- [ ] Verify sigstore sign/verify round-trip works with new identity/issuer
- [ ] Confirm interoperability tests pass (Go ↔ Python)
