### PR TITLE
Fix ambient OIDC credential handling

### DIFF
--- a/examples/sigstore/sign/main.go
+++ b/examples/sigstore/sign/main.go
@@ -20,8 +20,9 @@
 //
 // Authentication methods (in order of precedence):
 //  1. SIGSTORE_ID_TOKEN environment variable (explicit OIDC token)
-//  2. ACTIONS_ID_TOKEN_REQUEST_TOKEN (GitHub Actions ambient credentials)
-//  3. Interactive OAuth flow (browser-based authentication)
+//  2. GitHub Actions ambient OIDC (fetched via ACTIONS_ID_TOKEN_REQUEST_URL)
+//  3. Filesystem token at /var/run/sigstore/cosign/oidc-token
+//  4. Interactive OAuth flow (browser-based authentication)
 //
 // Usage:
 //

--- a/pkg/signing/sigstore/sigstore_signer_config.go
+++ b/pkg/signing/sigstore/sigstore_signer_config.go
@@ -16,9 +16,13 @@ package sigstore
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -114,15 +118,25 @@ func randomString(length int) string {
 	return cryptoutils.GenerateRandomURLSafeString(uint(length))
 }
 
+const (
+	defaultAudience = "sigstore"
+	//nolint:gosec // G101: not a credential, this is a well-known filesystem path
+	filesystemTokenPath = "/var/run/sigstore/cosign/oidc-token"
+	//nolint:gosec // G101: not a credential, this is an environment variable name
+	ambientTokenEnvVar     = "SIGSTORE_ID_TOKEN"
+	ghActionsRequestURLVar = "ACTIONS_ID_TOKEN_REQUEST_URL"
+	ghActionsRequestTknVar = "ACTIONS_ID_TOKEN_REQUEST_TOKEN"
+)
+
 // getIDToken obtains an OIDC identity token based on configuration.
 //
 // Priority order:
 // 1. Uses provided identity token if available
-// 2. Uses ambient credentials if configured
+// 2. Uses ambient credentials if configured (SIGSTORE_ID_TOKEN, GitHub Actions, filesystem)
 // 3. Falls back to interactive OAuth flow
 //
 // Returns the ID token string or an error if token acquisition fails.
-func (s *SigstoreSigner) getIDToken(_ context.Context) (string, error) {
+func (s *SigstoreSigner) getIDToken(ctx context.Context) (string, error) {
 	// If a token is explicitly provided, use it
 	if s.opts.IdentityToken != "" {
 		return s.opts.IdentityToken, nil
@@ -134,17 +148,12 @@ func (s *SigstoreSigner) getIDToken(_ context.Context) (string, error) {
 		return "", fmt.Errorf("failed to get OIDC issuer URL: %w", err)
 	}
 
-	// Check for ambient credentials (GitHub Actions, etc.)
 	if s.opts.UseAmbientCredentials {
-		// Try common environment variables for OIDC tokens
-		token := os.Getenv("SIGSTORE_ID_TOKEN")
-		if token == "" {
-			token = os.Getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
+		token, err := getAmbientToken(ctx)
+		if err != nil {
+			return "", fmt.Errorf("ambient credentials requested but no provider succeeded: %w", err)
 		}
-		if token != "" {
-			return token, nil
-		}
-		return "", fmt.Errorf("ambient credentials requested but SIGSTORE_ID_TOKEN or ACTIONS_ID_TOKEN_REQUEST_TOKEN not found")
+		return token, nil
 	}
 
 	// Get ID token using OAuth flow
@@ -158,11 +167,9 @@ func (s *SigstoreSigner) getIDToken(_ context.Context) (string, error) {
 	var token *oauthflow.OIDCIDToken
 
 	if s.opts.OAuthForceOob {
-		// Use out-of-band (OOB) OAuth flow
 		tokenGetter := &oobIDTokenGetter{}
 		token, err = oauthflow.OIDConnect(issuerURL, clientID, clientSecret, "", tokenGetter)
 	} else {
-		// Use interactive flow with automatic browser and local callback server
 		redirectURL := ""
 		tokenGetter := oauthflow.DefaultIDTokenGetter
 		token, err = oauthflow.OIDConnect(issuerURL, clientID, clientSecret, redirectURL, tokenGetter)
@@ -173,6 +180,92 @@ func (s *SigstoreSigner) getIDToken(_ context.Context) (string, error) {
 	}
 
 	return token.RawString, nil
+}
+
+// getAmbientToken tries each ambient OIDC provider in order:
+//  1. SIGSTORE_ID_TOKEN environment variable
+//  2. GitHub Actions OIDC token request
+//  3. Filesystem token at /var/run/sigstore/cosign/oidc-token
+func getAmbientToken(ctx context.Context) (string, error) {
+	var errs []string
+
+	// 1. Explicit env var
+	if token := os.Getenv(ambientTokenEnvVar); token != "" {
+		return token, nil
+	}
+
+	// 2. GitHub Actions
+	token, err := fetchGitHubActionsToken(ctx, defaultAudience)
+	if err == nil {
+		return token, nil
+	}
+	errs = append(errs, fmt.Sprintf("github-actions: %v", err))
+
+	// 3. Filesystem
+	token, err = readFilesystemToken(filesystemTokenPath)
+	if err == nil {
+		return token, nil
+	}
+	errs = append(errs, fmt.Sprintf("filesystem: %v", err))
+
+	return "", fmt.Errorf("%s not set; %s", ambientTokenEnvVar, strings.Join(errs, "; "))
+}
+
+// fetchGitHubActionsToken obtains an OIDC token from the GitHub Actions
+// runtime. ACTIONS_ID_TOKEN_REQUEST_TOKEN is a bearer credential used to
+// request the actual JWT from ACTIONS_ID_TOKEN_REQUEST_URL — it is not the
+// OIDC token itself.
+func fetchGitHubActionsToken(ctx context.Context, audience string) (string, error) {
+	requestURL := os.Getenv(ghActionsRequestURLVar)
+	requestToken := os.Getenv(ghActionsRequestTknVar)
+	if requestURL == "" || requestToken == "" {
+		return "", fmt.Errorf("%s and/or %s not set", ghActionsRequestURLVar, ghActionsRequestTknVar)
+	}
+
+	tokenURL := requestURL + "&audience=" + audience
+	//nolint:gosec // G704: URL is from ACTIONS_ID_TOKEN_REQUEST_URL set by GitHub Actions runtime
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, tokenURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", "bearer "+requestToken)
+
+	resp, err := http.DefaultClient.Do(req) //nolint:gosec // G704: see above
+	if err != nil {
+		return "", fmt.Errorf("requesting token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("token endpoint returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var payload struct {
+		Value string `json:"value"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", fmt.Errorf("decoding token response: %w", err)
+	}
+	if payload.Value == "" {
+		return "", fmt.Errorf("token endpoint returned empty token")
+	}
+
+	return payload.Value, nil
+}
+
+// readFilesystemToken reads an OIDC token from a well-known filesystem path,
+// used by providers that inject tokens as mounted files.
+func readFilesystemToken(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	token := strings.TrimSpace(string(data))
+	if token == "" {
+		return "", fmt.Errorf("token file %s is empty", path)
+	}
+	return token, nil
 }
 
 // getFulcioURL returns the Fulcio CA URL to use for certificate issuance.

--- a/pkg/signing/sigstore/sigstore_signer_config_test.go
+++ b/pkg/signing/sigstore/sigstore_signer_config_test.go
@@ -1,0 +1,230 @@
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sigstore
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// --- readFilesystemToken ---
+
+func TestReadFilesystemToken_Valid(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(f, []byte("my-jwt-token"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	tok, err := readFilesystemToken(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tok != "my-jwt-token" {
+		t.Errorf("got %q, want %q", tok, "my-jwt-token")
+	}
+}
+
+func TestReadFilesystemToken_TrimsWhitespace(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(f, []byte("  token-with-whitespace \n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	tok, err := readFilesystemToken(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tok != "token-with-whitespace" {
+		t.Errorf("got %q, want %q", tok, "token-with-whitespace")
+	}
+}
+
+func TestReadFilesystemToken_Missing(t *testing.T) {
+	_, err := readFilesystemToken(filepath.Join(t.TempDir(), "nonexistent"))
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestReadFilesystemToken_Empty(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(f, []byte(""), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := readFilesystemToken(f)
+	if err == nil {
+		t.Fatal("expected error for empty file")
+	}
+}
+
+func TestReadFilesystemToken_WhitespaceOnly(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(f, []byte("  \n\t  "), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := readFilesystemToken(f)
+	if err == nil {
+		t.Fatal("expected error for whitespace-only file")
+	}
+}
+
+// --- fetchGitHubActionsToken ---
+
+func TestFetchGitHubActionsToken_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "bearer test-bearer" {
+			t.Errorf("Authorization header = %q, want %q", got, "bearer test-bearer")
+		}
+		if got := r.URL.Query().Get("audience"); got != "sigstore" {
+			t.Errorf("audience = %q, want %q", got, "sigstore")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"value": "the-oidc-jwt"})
+	}))
+	defer srv.Close()
+
+	t.Setenv(ghActionsRequestURLVar, srv.URL+"?dummy=1")
+	t.Setenv(ghActionsRequestTknVar, "test-bearer")
+
+	tok, err := fetchGitHubActionsToken(context.Background(), "sigstore")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tok != "the-oidc-jwt" {
+		t.Errorf("got %q, want %q", tok, "the-oidc-jwt")
+	}
+}
+
+func TestFetchGitHubActionsToken_MissingEnvVars(t *testing.T) {
+	t.Setenv(ghActionsRequestURLVar, "")
+	t.Setenv(ghActionsRequestTknVar, "")
+
+	_, err := fetchGitHubActionsToken(context.Background(), "sigstore")
+	if err == nil {
+		t.Fatal("expected error when env vars are unset")
+	}
+}
+
+func TestFetchGitHubActionsToken_OnlyURLSet(t *testing.T) {
+	t.Setenv(ghActionsRequestURLVar, "https://example.com")
+	t.Setenv(ghActionsRequestTknVar, "")
+
+	_, err := fetchGitHubActionsToken(context.Background(), "sigstore")
+	if err == nil {
+		t.Fatal("expected error when only URL is set")
+	}
+}
+
+func TestFetchGitHubActionsToken_Non200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	t.Setenv(ghActionsRequestURLVar, srv.URL+"?dummy=1")
+	t.Setenv(ghActionsRequestTknVar, "bearer")
+
+	_, err := fetchGitHubActionsToken(context.Background(), "sigstore")
+	if err == nil {
+		t.Fatal("expected error for non-200 response")
+	}
+}
+
+func TestFetchGitHubActionsToken_EmptyValue(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"value": ""})
+	}))
+	defer srv.Close()
+
+	t.Setenv(ghActionsRequestURLVar, srv.URL+"?dummy=1")
+	t.Setenv(ghActionsRequestTknVar, "bearer")
+
+	_, err := fetchGitHubActionsToken(context.Background(), "sigstore")
+	if err == nil {
+		t.Fatal("expected error for empty token value")
+	}
+}
+
+func TestFetchGitHubActionsToken_InvalidJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("not-json"))
+	}))
+	defer srv.Close()
+
+	t.Setenv(ghActionsRequestURLVar, srv.URL+"?dummy=1")
+	t.Setenv(ghActionsRequestTknVar, "bearer")
+
+	_, err := fetchGitHubActionsToken(context.Background(), "sigstore")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+// --- getAmbientToken ---
+
+func TestGetAmbientToken_PrefersEnvVar(t *testing.T) {
+	t.Setenv(ambientTokenEnvVar, "env-token")
+	t.Setenv(ghActionsRequestURLVar, "")
+	t.Setenv(ghActionsRequestTknVar, "")
+
+	tok, err := getAmbientToken(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tok != "env-token" {
+		t.Errorf("got %q, want %q", tok, "env-token")
+	}
+}
+
+func TestGetAmbientToken_FallsBackToGitHubActions(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"value": "gha-token"})
+	}))
+	defer srv.Close()
+
+	t.Setenv(ambientTokenEnvVar, "")
+	t.Setenv(ghActionsRequestURLVar, srv.URL+"?dummy=1")
+	t.Setenv(ghActionsRequestTknVar, "bearer")
+
+	tok, err := getAmbientToken(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tok != "gha-token" {
+		t.Errorf("got %q, want %q", tok, "gha-token")
+	}
+}
+
+func TestGetAmbientToken_AllProvidersFail(t *testing.T) {
+	t.Setenv(ambientTokenEnvVar, "")
+	t.Setenv(ghActionsRequestURLVar, "")
+	t.Setenv(ghActionsRequestTknVar, "")
+
+	_, err := getAmbientToken(context.Background())
+	if err == nil {
+		t.Fatal("expected error when all providers fail")
+	}
+}


### PR DESCRIPTION
## Summary

- Fix `getIDToken()` which incorrectly used `ACTIONS_ID_TOKEN_REQUEST_TOKEN` as the OIDC ID token. That env var is a bearer credential for *requesting* the actual JWT — not the token itself.
- Add proper HTTP-based token fetching for GitHub Actions ambient OIDC
- Add filesystem provider support (`/var/run/sigstore/cosign/oidc-token`)
- Structure ambient providers with fallback chain: `SIGSTORE_ID_TOKEN` → GitHub Actions → filesystem
- Add 14 unit tests covering all three providers and edge cases

Fixes https://github.com/sampras343/model-transparency-go/issues/108

## Test plan

- [x] `readFilesystemToken`: valid, empty, missing, whitespace-only files
- [x] `fetchGitHubActionsToken`: success, missing env vars, non-200, empty value, invalid JSON (using httptest)
- [x] `getAmbientToken`: env var priority, GitHub Actions fallback, all-providers-fail
- [x] `golangci-lint run` passes (0 issues)
- [x] `go test ./...` passes (all 25 sigstore tests)
