### PR TITLE
Reject signing of empty models

### DIFF
--- a/pkg/modelartifact/modelartifact.go
+++ b/pkg/modelartifact/modelartifact.go
@@ -15,6 +15,7 @@
 package modelartifact
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -23,6 +24,10 @@ import (
 	"github.com/sigstore/model-signing/pkg/oci"
 	"github.com/sigstore/model-signing/pkg/utils"
 )
+
+// ErrEmptyModel is returned when a model contains no regular files after
+// applying exclusions. Per spec §6.1, an empty model MUST be rejected.
+var ErrEmptyModel = errors.New("model contains no regular files after exclusions; empty models must be rejected (spec §6.1)")
 
 // Canonicalize walks a model directory (or OCI manifest), hashes all files,
 // and returns a deterministic Manifest.
@@ -35,12 +40,23 @@ import (
 // structure), the manifest is created from the OCI layers instead of walking
 // the filesystem.
 func Canonicalize(modelPath string, opts Options) (*manifest.Manifest, error) {
-	// Handle OCI manifests
+	var m *manifest.Manifest
+	var err error
+
 	if oci.IsOCIManifest(modelPath) {
-		return canonicalizeOCI(modelPath, opts)
+		m, err = canonicalizeOCI(modelPath, opts)
+	} else {
+		m, err = canonicalizeDirectory(modelPath, opts)
+	}
+	if err != nil {
+		return nil, err
 	}
 
-	return canonicalizeDirectory(modelPath, opts)
+	if len(m.ResourceDescriptors()) == 0 {
+		return nil, ErrEmptyModel
+	}
+
+	return m, nil
 }
 
 // Compare checks whether two manifests match. Returns nil if they are equal,

--- a/pkg/modelartifact/modelartifact_test.go
+++ b/pkg/modelartifact/modelartifact_test.go
@@ -15,6 +15,7 @@
 package modelartifact
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -177,6 +178,50 @@ func TestCanonicalizeNonexistentPath(t *testing.T) {
 	_, err := Canonicalize("/nonexistent/path", Options{})
 	if err == nil {
 		t.Error("expected error for nonexistent path")
+	}
+}
+
+func TestCanonicalizeEmptyDirectory(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := Canonicalize(dir, Options{})
+	if err == nil {
+		t.Fatal("expected error for empty model directory")
+	}
+	if !errors.Is(err, ErrEmptyModel) {
+		t.Errorf("expected ErrEmptyModel, got: %v", err)
+	}
+}
+
+func TestCanonicalizeDirectoryWithOnlySubdirs(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "subdir", "nested"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Canonicalize(dir, Options{})
+	if err == nil {
+		t.Fatal("expected error for directory with only subdirectories (no regular files)")
+	}
+	if !errors.Is(err, ErrEmptyModel) {
+		t.Errorf("expected ErrEmptyModel, got: %v", err)
+	}
+}
+
+func TestCanonicalizeAllFilesIgnored(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "only-file.txt"), []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Canonicalize(dir, Options{
+		IgnorePaths: []string{"only-file.txt"},
+	})
+	if err == nil {
+		t.Fatal("expected error when all files are excluded by ignore paths")
+	}
+	if !errors.Is(err, ErrEmptyModel) {
+		t.Errorf("expected ErrEmptyModel, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds an `ErrEmptyModel` sentinel error to `modelartifact.Canonicalize` that rejects models with zero regular files after exclusions
- Prevents producing meaningless bundles with an empty `resources` list and a constant SHA-256 root digest (`e3b0c44...`) that would be interchangeable across any empty model
- The check applies to all signing methods (key, certificate, sigstore, pkcs11) and both directory and OCI manifest inputs

Fixes #95

## Test plan

- [x] `TestCanonicalizeEmptyDirectory` — empty temp dir returns `ErrEmptyModel`
- [x] `TestCanonicalizeDirectoryWithOnlySubdirs` — dir with only nested subdirs (no regular files) returns `ErrEmptyModel`
- [x] `TestCanonicalizeAllFilesIgnored` — single file excluded by `IgnorePaths` returns `ErrEmptyModel`
- [x] All existing `Canonicalize`, `Compare`, and `RoundTrip` tests still pass
- [x] `golangci-lint run` — zero issues
- [x] `go test ./...` — all packages pass
