### PR TITLE
Add EC P-521 key support for signing and verification

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -33,7 +33,6 @@ jobs:
           skip-result-upload: 'true'
           xfail: |
             test_roundtrip[key-empty-model-rejected
-            test_roundtrip[key-p521
             test_roundtrip[key-symlink-cycle
             test_roundtrip[key-symlink-default-rejected
             test_roundtrip[key-symlink-outside-root

--- a/pkg/signing/key/key_signer_test.go
+++ b/pkg/signing/key/key_signer_test.go
@@ -15,10 +15,108 @@
 package key
 
 import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
 	"os"
 	"path/filepath"
 	"testing"
 )
+
+func writeECKeyPEM(t *testing.T, dir string, curve elliptic.Curve) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(curve, rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate EC key: %v", err)
+	}
+	der, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("failed to marshal EC key: %v", err)
+	}
+	path := filepath.Join(dir, "key.pem")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if err := pem.Encode(f, &pem.Block{Type: "EC PRIVATE KEY", Bytes: der}); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestNewModelKeypair_ECCurves(t *testing.T) {
+	curves := []struct {
+		name  string
+		curve elliptic.Curve
+	}{
+		{"P-256", elliptic.P256()},
+		{"P-384", elliptic.P384()},
+		{"P-521", elliptic.P521()},
+	}
+
+	for _, tc := range curves {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			keyPath := writeECKeyPEM(t, dir, tc.curve)
+
+			kp, err := NewModelKeypair(keyPath, "")
+			if err != nil {
+				t.Fatalf("NewModelKeypair failed for %s: %v", tc.name, err)
+			}
+
+			if kp.GetKeyAlgorithm() != "ECDSA" {
+				t.Errorf("expected ECDSA, got %s", kp.GetKeyAlgorithm())
+			}
+
+			if len(kp.GetHint()) == 0 {
+				t.Error("expected non-empty key hint")
+			}
+
+			pubPEM, err := kp.GetPublicKeyPem()
+			if err != nil {
+				t.Fatalf("GetPublicKeyPem failed: %v", err)
+			}
+			if pubPEM == "" {
+				t.Error("expected non-empty public key PEM")
+			}
+		})
+	}
+}
+
+func TestModelKeypair_P521_SignData(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := writeECKeyPEM(t, dir, elliptic.P521())
+
+	kp, err := NewModelKeypair(keyPath, "")
+	if err != nil {
+		t.Fatalf("NewModelKeypair failed: %v", err)
+	}
+
+	data := []byte("test payload for P-521 signing")
+	sig, signed, err := kp.SignData(context.Background(), data)
+	if err != nil {
+		t.Fatalf("SignData failed: %v", err)
+	}
+
+	if len(sig) == 0 {
+		t.Error("expected non-empty signature")
+	}
+	if len(signed) == 0 {
+		t.Error("expected non-empty signed data")
+	}
+
+	pubKey, ok := kp.GetPublicKey().(*ecdsa.PublicKey)
+	if !ok {
+		t.Fatal("expected *ecdsa.PublicKey")
+	}
+	if pubKey.Curve != elliptic.P521() {
+		t.Errorf("expected P-521 curve, got %s", pubKey.Curve.Params().Name)
+	}
+}
 
 func TestNewKeySigner_MissingModelPath(t *testing.T) {
 	tmpDir := t.TempDir()

--- a/pkg/signing/key/keypair.go
+++ b/pkg/signing/key/keypair.go
@@ -37,7 +37,7 @@ type ModelKeypair struct {
 // NewModelKeypair loads a private key from a PEM file and returns a Keypair
 // that can be passed to sigstore-go's sign.Bundle().
 //
-// Supports ECDSA (P-256, P-384), RSA, and Ed25519 keys.
+// Supports ECDSA (P-256, P-384, P-521), RSA, and Ed25519 keys.
 // If password is non-empty, the key is assumed to be encrypted.
 func NewModelKeypair(keyPath string, password string) (*ModelKeypair, error) {
 	// Load private key from PEM file

--- a/pkg/signing/key_algorithm.go
+++ b/pkg/signing/key_algorithm.go
@@ -32,7 +32,7 @@ import (
 )
 
 // GetPublicKeyDetails determines the PublicKeyDetails enum for a given public key.
-// This function supports ECDSA (P-256, P-384), RSA (2048, 3072, 4096 bits), and Ed25519 keys.
+// This function supports ECDSA (P-256, P-384, P-521), RSA (2048, 3072, 4096 bits), and Ed25519 keys.
 func GetPublicKeyDetails(pubKey crypto.PublicKey) (protocommon.PublicKeyDetails, error) {
 	switch k := pubKey.(type) {
 	case *ecdsa.PublicKey:
@@ -41,6 +41,8 @@ func GetPublicKeyDetails(pubKey crypto.PublicKey) (protocommon.PublicKeyDetails,
 			return protocommon.PublicKeyDetails_PKIX_ECDSA_P256_SHA_256, nil
 		case elliptic.P384():
 			return protocommon.PublicKeyDetails_PKIX_ECDSA_P384_SHA_384, nil
+		case elliptic.P521():
+			return protocommon.PublicKeyDetails_PKIX_ECDSA_P521_SHA_512, nil
 		default:
 			return 0, fmt.Errorf("unsupported ECDSA curve: %s", k.Curve.Params().Name)
 		}

--- a/pkg/signing/key_algorithm_test.go
+++ b/pkg/signing/key_algorithm_test.go
@@ -58,7 +58,7 @@ func TestGetPublicKeyDetails(t *testing.T) {
 			wantError: false,
 		},
 		{
-			name: "ECDSA P-521 (unsupported)",
+			name: "ECDSA P-521",
 			keyFunc: func() (interface{}, error) {
 				key, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
 				if err != nil {
@@ -66,8 +66,8 @@ func TestGetPublicKeyDetails(t *testing.T) {
 				}
 				return &key.PublicKey, nil
 			},
-			wantAlg:   0,
-			wantError: true,
+			wantAlg:   protocommon.PublicKeyDetails_PKIX_ECDSA_P521_SHA_512,
+			wantError: false,
 		},
 		{
 			name: "ECDSA P-224 (unsupported)",
@@ -158,6 +158,26 @@ func TestGetPublicKeyDetails(t *testing.T) {
 				t.Errorf("Got algorithm %v, want %v", alg, tt.wantAlg)
 			}
 		})
+	}
+}
+
+func TestInitializeKeypairData_P521(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate P-521 key: %v", err)
+	}
+
+	algDetails, hint, err := InitializeKeypairData(&key.PublicKey)
+	if err != nil {
+		t.Fatalf("InitializeKeypairData failed for P-521: %v", err)
+	}
+
+	if algDetails.GetSignatureAlgorithm() != protocommon.PublicKeyDetails_PKIX_ECDSA_P521_SHA_512 {
+		t.Errorf("expected PKIX_ECDSA_P521_SHA_512, got %v", algDetails.GetSignatureAlgorithm())
+	}
+
+	if len(hint) == 0 {
+		t.Error("expected non-empty key hint")
 	}
 }
 

--- a/pkg/signing/pkcs11/pkcs11_keypair_test.go
+++ b/pkg/signing/pkcs11/pkcs11_keypair_test.go
@@ -53,9 +53,9 @@ func TestGetAlgorithmDetails_ECDSAKeys(t *testing.T) {
 		{
 			name:        "P-521 key",
 			curve:       elliptic.P521(),
-			wantHashAlg: 0,
-			wantSigAlg:  0,
-			wantErr:     true, // P-521 is unsupported by sigstore protobuf specs
+			wantHashAlg: protocommon.HashAlgorithm_SHA2_512,
+			wantSigAlg:  protocommon.PublicKeyDetails_PKIX_ECDSA_P521_SHA_512,
+			wantErr:     false,
 		},
 	}
 
@@ -216,6 +216,14 @@ func TestPKCS11Keypair_GetKeyAlgorithm(t *testing.T) {
 			name: "ECDSA P-384",
 			keyGen: func() interface{} {
 				key, _ := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+				return &key.PublicKey
+			},
+			wantType: "ECDSA",
+		},
+		{
+			name: "ECDSA P-521",
+			keyGen: func() interface{} {
+				key, _ := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
 				return &key.PublicKey
 			},
 			wantType: "ECDSA",

--- a/pkg/signing/pkcs11/pkcs11_signer.go
+++ b/pkg/signing/pkcs11/pkcs11_signer.go
@@ -27,7 +27,7 @@
 //   - Context: Manages PKCS#11 module loading and key discovery via crypto11
 //   - URI: Parser for RFC 7512 PKCS#11 URIs
 //
-// Supported key types: ECDSA (P-256, P-384), RSA (2048, 3072, 4096 bits)
+// Supported key types: ECDSA (P-256, P-384, P-521), RSA (2048, 3072, 4096 bits)
 package pkcs11
 
 import (

--- a/pkg/verify/crypto.go
+++ b/pkg/verify/crypto.go
@@ -28,7 +28,7 @@ import (
 )
 
 // CreateSignatureVerifier creates a sigstore signature.Verifier from a crypto.PublicKey.
-// Supports ECDSA (P-256, P-384), RSA (PKCS1v15 with SHA256), and Ed25519 keys.
+// Supports ECDSA (P-256, P-384, P-521), RSA (PKCS1v15 with SHA256), and Ed25519 keys.
 func CreateSignatureVerifier(pubKey crypto.PublicKey) (sigstoresig.Verifier, error) {
 	switch k := pubKey.(type) {
 	case *ecdsa.PublicKey:
@@ -38,6 +38,8 @@ func CreateSignatureVerifier(pubKey crypto.PublicKey) (sigstoresig.Verifier, err
 			hashFunc = crypto.SHA256
 		case elliptic.P384():
 			hashFunc = crypto.SHA384
+		case elliptic.P521():
+			hashFunc = crypto.SHA512
 		default:
 			return nil, fmt.Errorf("unsupported ECDSA curve: %s", k.Curve.Params().Name)
 		}

--- a/pkg/verify/crypto_test.go
+++ b/pkg/verify/crypto_test.go
@@ -1,0 +1,182 @@
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package verify
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+)
+
+func TestCreateSignatureVerifier(t *testing.T) {
+	tests := []struct {
+		name      string
+		keyFunc   func() (interface{}, error)
+		wantError bool
+	}{
+		{
+			name: "ECDSA P-256",
+			keyFunc: func() (interface{}, error) {
+				key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+				if err != nil {
+					return nil, err
+				}
+				return &key.PublicKey, nil
+			},
+		},
+		{
+			name: "ECDSA P-384",
+			keyFunc: func() (interface{}, error) {
+				key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+				if err != nil {
+					return nil, err
+				}
+				return &key.PublicKey, nil
+			},
+		},
+		{
+			name: "ECDSA P-521",
+			keyFunc: func() (interface{}, error) {
+				key, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+				if err != nil {
+					return nil, err
+				}
+				return &key.PublicKey, nil
+			},
+		},
+		{
+			name: "ECDSA P-224 (unsupported)",
+			keyFunc: func() (interface{}, error) {
+				key, err := ecdsa.GenerateKey(elliptic.P224(), rand.Reader)
+				if err != nil {
+					return nil, err
+				}
+				return &key.PublicKey, nil
+			},
+			wantError: true,
+		},
+		{
+			name: "RSA 2048",
+			keyFunc: func() (interface{}, error) {
+				key, err := rsa.GenerateKey(rand.Reader, 2048)
+				if err != nil {
+					return nil, err
+				}
+				return &key.PublicKey, nil
+			},
+		},
+		{
+			name: "Ed25519",
+			keyFunc: func() (interface{}, error) {
+				pub, _, err := ed25519.GenerateKey(rand.Reader)
+				return pub, err
+			},
+		},
+		{
+			name: "Unsupported type",
+			keyFunc: func() (interface{}, error) {
+				return "not a key", nil
+			},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key, err := tt.keyFunc()
+			if err != nil {
+				t.Fatalf("failed to generate key: %v", err)
+			}
+
+			verifier, err := CreateSignatureVerifier(key)
+			if tt.wantError {
+				if err == nil {
+					t.Error("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if verifier == nil {
+				t.Error("expected non-nil verifier")
+			}
+		})
+	}
+}
+
+func TestCreateTrustedPublicKeyMaterial(t *testing.T) {
+	tests := []struct {
+		name      string
+		keyFunc   func() (interface{}, error)
+		wantError bool
+	}{
+		{
+			name: "ECDSA P-256",
+			keyFunc: func() (interface{}, error) {
+				key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+				if err != nil {
+					return nil, err
+				}
+				return &key.PublicKey, nil
+			},
+		},
+		{
+			name: "ECDSA P-521",
+			keyFunc: func() (interface{}, error) {
+				key, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+				if err != nil {
+					return nil, err
+				}
+				return &key.PublicKey, nil
+			},
+		},
+		{
+			name: "Unsupported type",
+			keyFunc: func() (interface{}, error) {
+				return "not a key", nil
+			},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key, err := tt.keyFunc()
+			if err != nil {
+				t.Fatalf("failed to generate key: %v", err)
+			}
+
+			material, err := CreateTrustedPublicKeyMaterial(key)
+			if tt.wantError {
+				if err == nil {
+					t.Error("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if material == nil {
+				t.Error("expected non-nil trusted material")
+			}
+		})
+	}
+}

--- a/scripts/tests/keys/single-cert/gen-single-level-certs.sh
+++ b/scripts/tests/keys/single-cert/gen-single-level-certs.sh
@@ -39,6 +39,19 @@ openssl req -new -x509 \
 
 echo "  Created P-384 key and certificate"
 
+# Generate ECDSA P-521 key and self-signed certificate
+openssl ecparam -name secp521r1 -genkey -noout -out signing-key-p521.pem
+
+openssl req -new -x509 \
+    -key signing-key-p521.pem \
+    -out signing-cert-p521.pem \
+    -days 3650 \
+    -subj "/CN=single-level-test-p521" \
+    -addext "keyUsage=critical,digitalSignature" \
+    -addext "extendedKeyUsage=codeSigning"
+
+echo "  Created P-521 key and certificate"
+
 # Generate RSA 2048 key and self-signed certificate
 openssl genrsa -out signing-key-rsa.pem 2048
 

--- a/scripts/tests/test-certificate-hybrid.sh
+++ b/scripts/tests/test-certificate-hybrid.sh
@@ -20,6 +20,7 @@ generate_single_certs_if_needed() {
     # Check if certificates already exist
     if [ -f "${cert_dir}/signing-cert-p256.pem" ] && \
        [ -f "${cert_dir}/signing-cert-p384.pem" ] && \
+       [ -f "${cert_dir}/signing-cert-p521.pem" ] && \
        [ -f "${cert_dir}/signing-cert-rsa.pem" ]; then
         echo "Single-level certificates already exist, skipping generation"
         return 0
@@ -49,6 +50,17 @@ generate_single_certs_if_needed() {
         -addext "keyUsage=critical,digitalSignature" \
         -addext "extendedKeyUsage=codeSigning" 2>/dev/null
     echo "  Created P-384 key and certificate"
+
+    # Generate ECDSA P-521 key and self-signed certificate
+    openssl ecparam -name secp521r1 -genkey -noout -out "${cert_dir}/signing-key-p521.pem" 2>/dev/null
+    openssl req -new -x509 \
+        -key "${cert_dir}/signing-key-p521.pem" \
+        -out "${cert_dir}/signing-cert-p521.pem" \
+        -days 3650 \
+        -subj "/CN=single-level-test-p521" \
+        -addext "keyUsage=critical,digitalSignature" \
+        -addext "extendedKeyUsage=codeSigning" 2>/dev/null
+    echo "  Created P-521 key and certificate"
 
     # Generate RSA 2048 key and self-signed certificate
     openssl genrsa -out "${cert_dir}/signing-key-rsa.pem" 2048 2>/dev/null
@@ -157,9 +169,38 @@ if ! ${DIR}/model-signing \
 fi
 echo "  P-384 single certificate: PASSED"
 
+# Test with P-521 key
+echo ""
+echo "1c. Testing with ECDSA P-521 key..."
+
+if ! ${DIR}/model-signing \
+	sign certificate \
+	--signature "${sigfile_single}" \
+	--private-key ${DIR}/keys/single-cert/signing-key-p521.pem \
+	--signing-certificate ${DIR}/keys/single-cert/signing-cert-p521.pem \
+	"${MODEL_DIR}" 2>&1 | grep -v "^$"; then
+	echo "Error: 'sign certificate' with single P-521 cert failed"
+	exit 1
+fi
+
+if ! check_bundle_format "${sigfile_single}" "single"; then
+	echo "Error: Bundle format check failed for P-521"
+	exit 1
+fi
+
+if ! ${DIR}/model-signing \
+	verify certificate \
+	--signature "${sigfile_single}" \
+	--certificate-chain ${DIR}/keys/single-cert/signing-cert-p521.pem \
+	"${MODEL_DIR}" 2>&1 | grep -v "^$"; then
+	echo "Error: 'verify certificate' with single P-521 cert failed"
+	exit 1
+fi
+echo "  P-521 single certificate: PASSED"
+
 # Test with RSA key
 echo ""
-echo "1c. Testing with RSA-2048 key..."
+echo "1d. Testing with RSA-2048 key..."
 
 if ! ${DIR}/model-signing \
 	sign certificate \

--- a/scripts/tests/test-hardening.sh
+++ b/scripts/tests/test-hardening.sh
@@ -3,7 +3,7 @@
 # Hardening tests for model-signing
 #
 # This script tests:
-# 1. Key type variations (RSA, ECDSA P-256, P-384, Ed25519)
+# 1. Key type variations (RSA, ECDSA P-256, P-384, P-521, Ed25519)
 # 2. Signature tampering detection
 # 3. Model tampering detection
 # 4. Edge case models
@@ -153,19 +153,28 @@ if ! out=$(${DIR}/model-signing verify key \
 fi
 echo "  ECDSA P-384: PASSED"
 
-# --- ECDSA P-521 (unsupported by sigstore protobuf specs — should be rejected) ---
-echo "[Key Types] Testing ECDSA P-521 rejection (unsupported curve)..."
+# --- ECDSA P-521 ---
+echo "[Key Types] Testing ECDSA P-521..."
 generate_ecdsa_key "ecdsa-p521" "secp521r1"
 SIGFILE="${TMPDIR}/ecdsa-p521.sig"
 
-if ${DIR}/model-signing sign key \
+if ! ${DIR}/model-signing sign key \
 	--signature "${SIGFILE}" \
 	--private-key "${KEYSDIR}/ecdsa-p521.pem" \
 	"${MODELDIR}" >/dev/null 2>&1; then
-	echo "  Error: Sign with ECDSA P-521 should have been rejected"
+	echo "  Error: Sign with ECDSA P-521 failed"
 	exit 1
 fi
-echo "  ECDSA P-521 rejected: PASSED"
+
+if ! out=$(${DIR}/model-signing verify key \
+	--signature "${SIGFILE}" \
+	--public-key "${KEYSDIR}/ecdsa-p521-pub.pem" \
+	"${MODELDIR}" 2>&1); then
+	echo "  Error: Verify with ECDSA P-521 failed"
+	echo "  ${out}"
+	exit 1
+fi
+echo "  ECDSA P-521: PASSED"
 
 # --- Ed25519 ---
 echo "[Key Types] Testing Ed25519..."


### PR DESCRIPTION
## Summary

- Adds P-521 (with SHA-512) to `GetPublicKeyDetails` in `pkg/signing/key_algorithm.go` (signing path) and `CreateSignatureVerifier` in `pkg/verify/crypto.go` (verification path)
- Previously both functions only handled P-256 and P-384, rejecting P-521 with "unsupported ECDSA curve: P-521", which broke cross-client interoperability with the Python client
- Updates doc comments in `keypair.go`, `pkcs11_signer.go`, `key_algorithm.go`, and `crypto.go` to list P-521 as supported

Fixes #96

## Test plan

- [x] Updated `TestGetPublicKeyDetails` — P-521 now expects `PKIX_ECDSA_P521_SHA_512` instead of error
- [x] Added `TestInitializeKeypairData_P521` — full keypair init flow with P-521 key
- [x] Added `TestCreateSignatureVerifier` — covers P-256, P-384, P-521, P-224 (unsupported), RSA, Ed25519
- [x] Added `TestCreateTrustedPublicKeyMaterial` — covers P-256, P-521, unsupported type
- [x] `golangci-lint run` — zero issues
- [x] `go test ./...` — all packages pass
