### PR TITLE
Reject symlinks when allow_symlinks is false and skip non-regular files

### DIFF
--- a/pkg/config/hashing_config.go
+++ b/pkg/config/hashing_config.go
@@ -15,7 +15,9 @@
 package config
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -26,6 +28,10 @@ import (
 	"github.com/sigstore/model-signing/pkg/manifest"
 	"github.com/sigstore/model-signing/pkg/utils"
 )
+
+// ErrSymlinkNotAllowed is returned when a symbolic link is encountered during
+// file enumeration and allow_symlinks is false (the default per OMS spec §6.1.1).
+var ErrSymlinkNotAllowed = errors.New("symbolic link encountered but allow_symlinks is false")
 
 // HashingConfig holds configuration for hashing models.
 //
@@ -261,22 +267,33 @@ func (c *HashingConfig) Hash(modelPath string, filesToHash []string) (*manifest.
 func (c *HashingConfig) walkDirectory(modelPath string) ([]string, error) {
 	var files []string
 
-	err := filepath.Walk(modelPath, func(path string, info os.FileInfo, err error) error {
+	err := filepath.WalkDir(modelPath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
-		// Skip directories
-		if info.IsDir() {
+		// Check if path should be ignored before other checks so we
+		// can skip entire directory subtrees early via SkipDir.
+		if c.shouldIgnorePath(path, modelPath) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 
-		// Check if it's a symlink
-		if info.Mode()&os.ModeSymlink != 0 {
+		if d.IsDir() {
+			return nil
+		}
+
+		// DirEntry.Type() returns the file type bits without an extra syscall.
+		if d.Type()&os.ModeSymlink != 0 {
 			if !c.allowSymlinks {
-				return nil // Skip symlinks if not allowed
+				relPath, relErr := filepath.Rel(modelPath, path)
+				if relErr != nil {
+					relPath = path
+				}
+				return fmt.Errorf("%w: %s", ErrSymlinkNotAllowed, relPath)
 			}
-			// Resolve symlink and check if target exists
 			target, err := filepath.EvalSymlinks(path)
 			if err != nil {
 				return fmt.Errorf("failed to resolve symlink %s: %w", path, err)
@@ -285,16 +302,14 @@ func (c *HashingConfig) walkDirectory(modelPath string) ([]string, error) {
 			if err != nil {
 				return fmt.Errorf("failed to stat symlink target %s: %w", target, err)
 			}
-			if targetInfo.IsDir() {
-				return nil // Skip directory symlinks
+			if !targetInfo.Mode().IsRegular() {
+				return nil
 			}
+			files = append(files, path)
+			return nil
 		}
 
-		// Check if path should be ignored
-		if c.shouldIgnorePath(path, modelPath) {
-			if info.IsDir() {
-				return filepath.SkipDir
-			}
+		if !d.Type().IsRegular() {
 			return nil
 		}
 

--- a/pkg/config/hashing_config_test.go
+++ b/pkg/config/hashing_config_test.go
@@ -15,8 +15,11 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
+	"syscall"
 	"testing"
 )
 
@@ -577,5 +580,128 @@ func TestHash_WithSpecificFilesWithoutIgnoreGitPaths(t *testing.T) {
 	// Verify that both files are in the manifest
 	if len(resourceDescriptors) != 2 {
 		t.Errorf("Expected 2 files in manifest (file1.txt, .gitignore), got %d", len(resourceDescriptors))
+	}
+}
+
+func TestWalkDirectory_SymlinkRejectedWhenNotAllowed(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "real.txt")
+	if err := os.WriteFile(target, []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "link.txt")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skip("symlinks not supported on this platform")
+	}
+
+	hc := NewHashingConfig()
+	hc.SetAllowSymlinks(false)
+	_, err := hc.Hash(dir, nil)
+	if err == nil {
+		t.Fatal("expected error when symlink encountered with allow_symlinks=false")
+	}
+	if !errors.Is(err, ErrSymlinkNotAllowed) {
+		t.Fatalf("expected ErrSymlinkNotAllowed, got: %v", err)
+	}
+}
+
+func TestWalkDirectory_SymlinkAllowedIncludesBothEntries(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "real.txt")
+	if err := os.WriteFile(target, []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "link.txt")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skip("symlinks not supported on this platform")
+	}
+
+	hc := NewHashingConfig()
+	hc.SetAllowSymlinks(true)
+	hc.UseFileSerialization("sha256", true, nil)
+	m, err := hc.Hash(dir, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	descs := m.ResourceDescriptors()
+	if len(descs) != 2 {
+		t.Fatalf("expected 2 descriptors (real.txt + link.txt), got %d", len(descs))
+	}
+	ids := map[string]bool{}
+	for _, d := range descs {
+		ids[d.Identifier] = true
+	}
+	if !ids["real.txt"] || !ids["link.txt"] {
+		t.Errorf("expected real.txt and link.txt, got %v", ids)
+	}
+}
+
+func TestWalkDirectory_RelativeSymlinkRejected(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("a"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("a.txt", filepath.Join(dir, "b.txt")); err != nil {
+		t.Skip("symlinks not supported on this platform")
+	}
+
+	hc := NewHashingConfig()
+	hc.SetAllowSymlinks(false)
+	_, err := hc.Hash(dir, nil)
+	if !errors.Is(err, ErrSymlinkNotAllowed) {
+		t.Fatalf("expected ErrSymlinkNotAllowed for relative symlink, got: %v", err)
+	}
+}
+
+func TestWalkDirectory_FIFOSkipped(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("FIFOs not supported on Windows")
+	}
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "ok.txt"), []byte("ok"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	fifo := filepath.Join(dir, "pipe.fifo")
+	if err := syscall.Mkfifo(fifo, 0600); err != nil {
+		t.Skipf("mkfifo not supported: %v", err)
+	}
+
+	hc := NewHashingConfig()
+	hc.UseFileSerialization("sha256", false, nil)
+	m, err := hc.Hash(dir, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	descs := m.ResourceDescriptors()
+	if len(descs) != 1 {
+		t.Fatalf("expected 1 descriptor (ok.txt only), got %d", len(descs))
+	}
+	if descs[0].Identifier != "ok.txt" {
+		t.Errorf("expected ok.txt, got %s", descs[0].Identifier)
+	}
+}
+
+func TestWalkDirectory_OnlySymlinks_RejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "hidden.txt")
+	if err := os.WriteFile(target, []byte("h"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(dir, "only-link.txt")); err != nil {
+		t.Skip("symlinks not supported on this platform")
+	}
+	// Remove the real file so the only entry is a symlink
+	if err := os.Remove(target); err != nil {
+		t.Fatal(err)
+	}
+
+	hc := NewHashingConfig()
+	hc.SetAllowSymlinks(false)
+	_, err := hc.Hash(dir, nil)
+	if !errors.Is(err, ErrSymlinkNotAllowed) {
+		t.Fatalf("expected ErrSymlinkNotAllowed, got: %v", err)
 	}
 }

--- a/pkg/modelartifact/modelartifact_test.go
+++ b/pkg/modelartifact/modelartifact_test.go
@@ -181,6 +181,43 @@ func TestCanonicalizeNonexistentPath(t *testing.T) {
 	}
 }
 
+func TestCanonicalizeSymlinkRejected(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "real.txt")
+	if err := os.WriteFile(target, []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(dir, "link.txt")); err != nil {
+		t.Skip("symlinks not supported on this platform")
+	}
+
+	_, err := Canonicalize(dir, Options{AllowSymlinks: false})
+	if err == nil {
+		t.Fatal("expected error when symlink encountered with allow_symlinks=false")
+	}
+}
+
+func TestCanonicalizeSymlinkAllowed(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "real.txt")
+	if err := os.WriteFile(target, []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(dir, "link.txt")); err != nil {
+		t.Skip("symlinks not supported on this platform")
+	}
+
+	m, err := Canonicalize(dir, Options{AllowSymlinks: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	descs := m.ResourceDescriptors()
+	if len(descs) != 2 {
+		t.Fatalf("expected 2 descriptors, got %d", len(descs))
+	}
+}
+
 func TestCanonicalizeEmptyDirectory(t *testing.T) {
 	dir := t.TempDir()
 

--- a/scripts/tests/test-hardening.sh
+++ b/scripts/tests/test-hardening.sh
@@ -857,12 +857,12 @@ SIGFILE_NO_SYMLINK="${TMPDIR}/symlinks-no.sig"
 echo "target-content" > "${MODELDIR}/target.txt"
 ln -s target.txt "${MODELDIR}/link.txt"
 
-# Sign without --allow-symlinks succeeds but skips symlinks
-if ! ${DIR}/model-signing sign key \
+# Sign without --allow-symlinks MUST fail (OMS spec §6.1.1)
+if ${DIR}/model-signing sign key \
 	--signature "${SIGFILE_NO_SYMLINK}" \
 	--private-key "${KEYSDIR}/flags-key.pem" \
 	"${MODELDIR}" >/dev/null 2>&1; then
-	echo "  Error: Sign should succeed (symlinks are skipped by default)"
+	echo "  Error: Sign should fail when symlinks are present and allow_symlinks is false"
 	exit 1
 fi
 
@@ -877,12 +877,12 @@ if ! ${DIR}/model-signing sign key \
 fi
 
 # Verify signature that includes symlinks requires --allow-symlinks
-# Without the flag, verification fails because symlink is in signature but skipped
+# Without the flag, verification fails because symlink triggers an error
 if ${DIR}/model-signing verify key \
 	--signature "${SIGFILE}" \
 	--public-key "${KEYSDIR}/flags-key-pub.pem" \
 	"${MODELDIR}" >/dev/null 2>&1; then
-	echo "  Error: Verify should fail when signature includes symlink but flag not passed"
+	echo "  Error: Verify should fail when symlink present and allow_symlinks is false"
 	exit 1
 fi
 
@@ -896,12 +896,25 @@ if ! ${DIR}/model-signing verify key \
 	exit 1
 fi
 
-# Verify signature without symlinks also works (symlinks skipped during verify)
-if ! ${DIR}/model-signing verify key \
+# Remove symlinks, then sign and verify without --allow-symlinks
+rm "${MODELDIR}/link.txt"
+
+if ! ${DIR}/model-signing sign key \
+	--signature "${SIGFILE_NO_SYMLINK}" \
+	--private-key "${KEYSDIR}/flags-key.pem" \
+	"${MODELDIR}" >/dev/null 2>&1; then
+	echo "  Error: Sign should succeed when no symlinks are present"
+	exit 1
+fi
+
+# Re-create symlink to verify it causes an error on verify too
+ln -s target.txt "${MODELDIR}/link.txt"
+
+if ${DIR}/model-signing verify key \
 	--signature "${SIGFILE_NO_SYMLINK}" \
 	--public-key "${KEYSDIR}/flags-key-pub.pem" \
 	"${MODELDIR}" >/dev/null 2>&1; then
-	echo "  Error: Verify should succeed when symlinks are skipped"
+	echo "  Error: Verify should fail when symlink present and allow_symlinks is false"
 	exit 1
 fi
 echo "  --allow-symlinks: PASSED"

--- a/scripts/tests/test-sign-verify.sh
+++ b/scripts/tests/test-sign-verify.sh
@@ -175,8 +175,9 @@ if ${DIR}/model-signing \
 	exit 1
 fi
 
-# This should pass without having to pass --allow-symlinks since the symlink
-# will be ignored
+# Symlinks cause an error when allow_symlinks is false (OMS spec §6.1.1),
+# so we need --allow-symlinks to let the walker proceed, then
+# --ignore-unsigned-files to accept the extra unsigned files.
 echo
 echo "Pass signature verification by ignoring any unsigned files or symlinks"
 if ! ${DIR}/model-signing \
@@ -184,9 +185,10 @@ if ! ${DIR}/model-signing \
 	--signature "$(basename "${sigfile}")" \
 	--certificate-chain "${DIR}/keys/certificate/ca-cert.pem" \
 	--ignore-paths "$(basename "${ignorefile}")" \
+	--allow-symlinks \
 	--ignore-unsigned-files \
 	. ; then
-	echo "Error: 'verify certificate' failed with --ignore-unsigned-files while passing --allow-symlinks"
+	echo "Error: 'verify certificate' failed with --allow-symlinks --ignore-unsigned-files"
 	exit 1
 fi
 

--- a/test/conformance/hash.go
+++ b/test/conformance/hash.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sync"
@@ -104,15 +105,24 @@ func hashModelParallel(modelPath, hashAlgorithm string, shardSize int64, chunkSi
 }
 
 // walkFiles collects all regular file paths under a directory.
+// Returns an error if symlinks are encountered (OMS spec §6.1.1)
+// and skips non-regular files per OMS spec §6.1.
 func walkFiles(root string) ([]string, error) {
 	var files []string
-	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if !info.IsDir() {
-			files = append(files, path)
+		if d.IsDir() {
+			return nil
 		}
+		if d.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("symbolic link encountered: %s", path)
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		files = append(files, path)
 		return nil
 	})
 	return files, err


### PR DESCRIPTION
## Summary

- **Bug**: `walkDirectory` used `filepath.Walk` which resolves file symlinks before returning `FileInfo`, making the `ModeSymlink` check dead code. Symlinks were silently followed and hashed as regular files even when `allow_symlinks=false`. It also filtered only `IsDir()`, allowing FIFOs, sockets, and device nodes to be opened and hashed — blocking indefinitely on named pipes.
- **Fix**: Switch to `filepath.WalkDir` which uses `os.Lstat` and reports `fs.DirEntry.Type()` accurately. Return `ErrSymlinkNotAllowed` error when symlinks are encountered under the default policy. Use `Type().IsRegular()` to skip all non-regular files. When `allow_symlinks` is true, verify resolved targets are regular files. Move `shouldIgnorePath` before `IsDir()` to skip ignored directory subtrees early via `filepath.SkipDir`.
- **Scope**: Fixed in both the main walker (`pkg/config/hashing_config.go`) and the conformance test walker (`test/conformance/hash.go`).

Closes #97
Closes #117

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` — all existing tests pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] New tests: symlink rejected (absolute + relative), symlink allowed (both entries present), FIFO skipped, symlink-only directory errors
- [x] Integration-level tests: `Canonicalize` with `AllowSymlinks: false/true` propagates correctly
- [x] CI: CLI integration tests and hardening tests pass with updated shell test scripts