### PR TITLE
Add symlink warnings for targets outside root and cycles

### DIFF
--- a/pkg/config/hashing_config.go
+++ b/pkg/config/hashing_config.go
@@ -25,6 +25,7 @@ import (
 	hashengines "github.com/sigstore/model-signing/pkg/hashing/engines"
 	hashio "github.com/sigstore/model-signing/pkg/hashing/engines/io"
 	_ "github.com/sigstore/model-signing/pkg/hashing/engines/memory" // Register default hash engines (sha256, blake2b)
+	"github.com/sigstore/model-signing/pkg/logging"
 	"github.com/sigstore/model-signing/pkg/manifest"
 	"github.com/sigstore/model-signing/pkg/utils"
 )
@@ -57,6 +58,9 @@ type HashingConfig struct {
 
 	// Chunk size for file reading (0 = read all at once)
 	chunkSize int
+
+	// Logger for warnings (e.g. symlink targets outside model root)
+	logger logging.Logger
 }
 
 // PathLike is a type alias for path-like strings.
@@ -196,6 +200,13 @@ func (c *HashingConfig) SetChunkSize(size int) *HashingConfig {
 	return c
 }
 
+// SetLogger sets the logger for warnings during file enumeration
+// (e.g. symlink targets outside model root, symlink cycles).
+func (c *HashingConfig) SetLogger(logger logging.Logger) *HashingConfig {
+	c.logger = logger
+	return c
+}
+
 // Hash hashes a model directory and returns a manifest.
 //
 // If filesToHash is nil, all files in the directory are hashed (subject to ignore rules).
@@ -265,9 +276,15 @@ func (c *HashingConfig) Hash(modelPath string, filesToHash []string) (*manifest.
 // Returns a list of absolute file paths that should be hashed, respecting
 // ignore rules and symlink configuration.
 func (c *HashingConfig) walkDirectory(modelPath string) ([]string, error) {
+	absModelRoot, err := filepath.Abs(modelPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve model path: %w", err)
+	}
+	absModelRoot = filepath.Clean(absModelRoot) + string(filepath.Separator)
+
 	var files []string
 
-	err := filepath.WalkDir(modelPath, func(path string, d fs.DirEntry, err error) error {
+	err = filepath.WalkDir(modelPath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -296,7 +313,12 @@ func (c *HashingConfig) walkDirectory(modelPath string) ([]string, error) {
 			}
 			target, err := filepath.EvalSymlinks(path)
 			if err != nil {
-				return fmt.Errorf("failed to resolve symlink %s: %w", path, err)
+				// EvalSymlinks fails on cycles (OMS spec §6.1.1)
+				c.warnf("symlink cycle or broken link: %s: %v", path, err)
+				return nil
+			}
+			if !strings.HasPrefix(filepath.Clean(target)+string(filepath.Separator), absModelRoot) {
+				c.warnf("symlink target outside model root: %s -> %s", path, target)
 			}
 			targetInfo, err := os.Stat(target)
 			if err != nil {
@@ -529,5 +551,11 @@ func (c *HashingConfig) GetSerializationType() manifest.SerializationType {
 			c.allowSymlinks,
 			c.ignoredPaths,
 		)
+	}
+}
+
+func (c *HashingConfig) warnf(format string, args ...interface{}) {
+	if c.logger != nil {
+		c.logger.Warn(format, args...)
 	}
 }

--- a/pkg/config/hashing_config_test.go
+++ b/pkg/config/hashing_config_test.go
@@ -16,12 +16,48 @@ package config
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
+	"sync"
 	"syscall"
 	"testing"
+
+	"github.com/sigstore/model-signing/pkg/logging"
 )
+
+type capturingLogger struct {
+	mu       sync.Mutex
+	warnings []string
+}
+
+func (l *capturingLogger) Debug(string, ...interface{}) {}
+func (l *capturingLogger) Debugln(string)               {}
+func (l *capturingLogger) Info(string, ...interface{})  {}
+func (l *capturingLogger) Infoln(string)                {}
+func (l *capturingLogger) Error(string, ...interface{}) {}
+func (l *capturingLogger) Errorln(string)               {}
+func (l *capturingLogger) GetLevel() logging.LogLevel   { return logging.LevelDebug }
+func (l *capturingLogger) Silent() bool                 { return false }
+func (l *capturingLogger) Warnln(msg string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.warnings = append(l.warnings, msg)
+}
+func (l *capturingLogger) Warn(format string, args ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.warnings = append(l.warnings, fmt.Sprintf(format, args...))
+}
+func (l *capturingLogger) WithField(string, interface{}) logging.Logger     { return l }
+func (l *capturingLogger) WithFields(map[string]interface{}) logging.Logger { return l }
+func (l *capturingLogger) Warnings() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]string{}, l.warnings...)
+}
 
 func TestNewHashingConfig(t *testing.T) {
 	config := NewHashingConfig()
@@ -693,7 +729,6 @@ func TestWalkDirectory_OnlySymlinks_RejectsSymlink(t *testing.T) {
 	if err := os.Symlink(target, filepath.Join(dir, "only-link.txt")); err != nil {
 		t.Skip("symlinks not supported on this platform")
 	}
-	// Remove the real file so the only entry is a symlink
 	if err := os.Remove(target); err != nil {
 		t.Fatal(err)
 	}
@@ -703,5 +738,110 @@ func TestWalkDirectory_OnlySymlinks_RejectsSymlink(t *testing.T) {
 	_, err := hc.Hash(dir, nil)
 	if !errors.Is(err, ErrSymlinkNotAllowed) {
 		t.Fatalf("expected ErrSymlinkNotAllowed, got: %v", err)
+	}
+}
+
+func TestWalkDirectory_SymlinkOutsideRootWarns(t *testing.T) {
+	modelDir := t.TempDir()
+	outsideDir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(modelDir, "real.txt"), []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	outsideFile := filepath.Join(outsideDir, "external.txt")
+	if err := os.WriteFile(outsideFile, []byte("external"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outsideFile, filepath.Join(modelDir, "link.txt")); err != nil {
+		t.Skip("symlinks not supported on this platform")
+	}
+
+	logger := &capturingLogger{}
+	hc := NewHashingConfig()
+	hc.SetAllowSymlinks(true)
+	hc.SetLogger(logger)
+	hc.UseFileSerialization("sha256", true, nil)
+
+	m, err := hc.Hash(modelDir, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m == nil {
+		t.Fatal("expected non-nil manifest")
+	}
+
+	warnings := logger.Warnings()
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "outside model root") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected warning about symlink target outside model root, got: %v", warnings)
+	}
+}
+
+func TestWalkDirectory_SymlinkCycleWarns(t *testing.T) {
+	modelDir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(modelDir, "real.txt"), []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("self", filepath.Join(modelDir, "self")); err != nil {
+		t.Skip("symlinks not supported on this platform")
+	}
+
+	logger := &capturingLogger{}
+	hc := NewHashingConfig()
+	hc.SetAllowSymlinks(true)
+	hc.SetLogger(logger)
+	hc.UseFileSerialization("sha256", true, nil)
+
+	_, err := hc.Hash(modelDir, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	warnings := logger.Warnings()
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "cycle") || strings.Contains(w, "broken link") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected warning about symlink cycle, got: %v", warnings)
+	}
+}
+
+func TestWalkDirectory_SymlinkInsideRootNoWarning(t *testing.T) {
+	modelDir := t.TempDir()
+
+	target := filepath.Join(modelDir, "real.txt")
+	if err := os.WriteFile(target, []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(modelDir, "link.txt")); err != nil {
+		t.Skip("symlinks not supported on this platform")
+	}
+
+	logger := &capturingLogger{}
+	hc := NewHashingConfig()
+	hc.SetAllowSymlinks(true)
+	hc.SetLogger(logger)
+	hc.UseFileSerialization("sha256", true, nil)
+
+	_, err := hc.Hash(modelDir, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, w := range logger.Warnings() {
+		if strings.Contains(w, "outside model root") {
+			t.Errorf("unexpected outside-root warning for internal symlink: %s", w)
+		}
 	}
 }

--- a/pkg/modelartifact/modelartifact.go
+++ b/pkg/modelartifact/modelartifact.go
@@ -186,5 +186,9 @@ func buildHashingConfig(opts Options) *config.HashingConfig {
 		hc.SetIgnoredPaths(opts.IgnorePaths, true)
 	}
 
+	if opts.Logger != nil {
+		hc.SetLogger(opts.Logger)
+	}
+
 	return hc
 }


### PR DESCRIPTION
## Summary

- When `allow_symlinks=true`, emit warnings per OMS spec §6.1.1:
  - Warn if a resolved symlink target falls outside the model root directory
  - Warn if `filepath.EvalSymlinks` fails (indicating a cycle or broken link)
- Adds a `Logger` field to `HashingConfig` and wires it from `modelartifact.Options` so warnings are surfaced to callers
- Uses `filepath.Abs` + trailing separator for robust prefix comparison (avoids false matches like `/tmp/model` vs `/tmp/model2`)

Closes #123

## Test plan

- [x] `TestWalkDirectory_SymlinkOutsideRootWarns` — verifies warning emitted for external target
- [x] `TestWalkDirectory_SymlinkCycleWarns` — verifies warning emitted for self-referential symlink
- [x] `TestWalkDirectory_SymlinkInsideRootNoWarning` — verifies no false warning for internal symlink
- [x] Full test suite passes (`go test ./...`)
- [x] Linter passes (`golangci-lint run ./...`)
