### PR TITLE
Reject file paths that are not valid UTF-8

### DIFF
--- a/pkg/config/hashing_config.go
+++ b/pkg/config/hashing_config.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"unicode/utf8"
 
 	hashengines "github.com/sigstore/model-signing/pkg/hashing/engines"
 	hashio "github.com/sigstore/model-signing/pkg/hashing/engines/io"
@@ -33,6 +34,10 @@ import (
 // ErrSymlinkNotAllowed is returned when a symbolic link is encountered during
 // file enumeration and allow_symlinks is false (the default per OMS spec §6.1.1).
 var ErrSymlinkNotAllowed = errors.New("symbolic link encountered but allow_symlinks is false")
+
+// ErrInvalidUTF8Path is returned when a file path contains byte sequences
+// that are not valid UTF-8 (spec §6.1.2).
+var ErrInvalidUTF8Path = errors.New("file path is not valid UTF-8")
 
 // HashingConfig holds configuration for hashing models.
 //
@@ -407,10 +412,13 @@ func (c *HashingConfig) hashFiles(modelPath string, filePaths []string) ([]manif
 	items := make([]manifest.ManifestItem, 0, len(filePaths))
 
 	for _, filePath := range filePaths {
-		// Get relative path for manifest
 		relPath, err := filepath.Rel(modelPath, filePath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get relative path for %s: %w", filePath, err)
+		}
+
+		if !utf8.ValidString(relPath) {
+			return nil, fmt.Errorf("%w: %q", ErrInvalidUTF8Path, relPath)
 		}
 
 		// Create file hasher
@@ -441,10 +449,13 @@ func (c *HashingConfig) hashFilesWithShards(modelPath string, filePaths []string
 	items := make([]manifest.ManifestItem, 0)
 
 	for _, filePath := range filePaths {
-		// Get relative path for manifest
 		relPath, err := filepath.Rel(modelPath, filePath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get relative path for %s: %w", filePath, err)
+		}
+
+		if !utf8.ValidString(relPath) {
+			return nil, fmt.Errorf("%w: %q", ErrInvalidUTF8Path, relPath)
 		}
 
 		// Get file size

--- a/pkg/config/hashing_config_test.go
+++ b/pkg/config/hashing_config_test.go
@@ -845,3 +845,76 @@ func TestWalkDirectory_SymlinkInsideRootNoWarning(t *testing.T) {
 		}
 	}
 }
+
+func TestHashFiles_InvalidUTF8PathRejected(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not allow invalid UTF-8 in filenames")
+	}
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "valid.txt"), []byte("ok"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a file with invalid UTF-8 bytes in the name (0xff is never valid in UTF-8)
+	invalidName := "bad\xffname.txt"
+	if err := os.WriteFile(filepath.Join(dir, invalidName), []byte("data"), 0644); err != nil {
+		t.Skipf("OS rejected invalid UTF-8 filename: %v", err)
+	}
+
+	hc := NewHashingConfig()
+	hc.UseFileSerialization("sha256", false, nil)
+
+	_, err := hc.Hash(dir, nil)
+	if err == nil {
+		t.Fatal("expected error for invalid UTF-8 path")
+	}
+	if !errors.Is(err, ErrInvalidUTF8Path) {
+		t.Fatalf("expected ErrInvalidUTF8Path, got: %v", err)
+	}
+}
+
+func TestHashShards_InvalidUTF8PathRejected(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not allow invalid UTF-8 in filenames")
+	}
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "valid.txt"), []byte("ok"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	invalidName := "bad\xffname.txt"
+	if err := os.WriteFile(filepath.Join(dir, invalidName), []byte("data"), 0644); err != nil {
+		t.Skipf("OS rejected invalid UTF-8 filename: %v", err)
+	}
+
+	hc := NewHashingConfig()
+	hc.UseShardSerialization("sha256", 16, false, nil)
+
+	_, err := hc.Hash(dir, nil)
+	if err == nil {
+		t.Fatal("expected error for invalid UTF-8 path")
+	}
+	if !errors.Is(err, ErrInvalidUTF8Path) {
+		t.Fatalf("expected ErrInvalidUTF8Path, got: %v", err)
+	}
+}
+
+func TestHashFiles_ValidUTF8PathAccepted(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "日本語.txt"), []byte("unicode"), 0644); err != nil {
+		t.Skipf("OS rejected unicode filename: %v", err)
+	}
+
+	hc := NewHashingConfig()
+	hc.UseFileSerialization("sha256", false, nil)
+
+	m, err := hc.Hash(dir, nil)
+	if err != nil {
+		t.Fatalf("valid UTF-8 path should be accepted: %v", err)
+	}
+	if len(m.ResourceDescriptors()) != 1 {
+		t.Fatalf("expected 1 descriptor, got %d", len(m.ResourceDescriptors()))
+	}
+}


### PR DESCRIPTION
## Summary

- Add `utf8.ValidString` validation after computing relative paths in `hashFiles` and `hashFilesWithShards`, rejecting files whose names contain invalid UTF-8 byte sequences
- Introduces `ErrInvalidUTF8Path` sentinel error for callers to check via `errors.Is`
- Implements OMS spec §6.1.2: *"All path components MUST be representable as valid UTF-8. If a filename contains byte sequences that are not valid UTF-8, the signer MUST reject the file."*

Closes #119

## Test plan

- [x] `TestHashFiles_InvalidUTF8PathRejected` — file with `\xff` in name is rejected with `ErrInvalidUTF8Path`
- [x] `TestHashShards_InvalidUTF8PathRejected` — same check for shard serialization
- [x] `TestHashFiles_ValidUTF8PathAccepted` — valid unicode filename (Japanese) accepted
- [x] Full test suite passes (`go test ./...`)
- [x] Linter passes (`golangci-lint run ./...`)
- [x] Hardening tests pass (including unicode filenames edge case)
