### PR TITLE
Validate _type field in UnmarshalPayload

### DIFF
--- a/pkg/modelartifact/modelartifact_test.go
+++ b/pkg/modelartifact/modelartifact_test.go
@@ -432,11 +432,14 @@ func TestUnmarshalPayloadInvalid(t *testing.T) {
 	tests := []struct {
 		name    string
 		payload string
+		errMsg  string
 	}{
-		{"empty", ""},
-		{"invalid json", "{not json}"},
-		{"missing predicateType", `{"subject": []}`},
-		{"wrong predicateType", `{"predicateType": "wrong", "subject": []}`},
+		{"empty", "", "unmarshal"},
+		{"invalid json", "{not json}", "unmarshal"},
+		{"missing _type", `{"predicateType": "x", "subject": []}`, "_type field missing"},
+		{"wrong _type", `{"_type": "https://in-toto.io/Statement/v0", "predicateType": "x"}`, "unsupported statement type"},
+		{"missing predicateType", `{"_type": "https://in-toto.io/Statement/v1", "subject": []}`, "predicateType"},
+		{"wrong predicateType", `{"_type": "https://in-toto.io/Statement/v1", "predicateType": "wrong"}`, "predicate type mismatch"},
 	}
 
 	for _, tt := range tests {
@@ -444,6 +447,8 @@ func TestUnmarshalPayloadInvalid(t *testing.T) {
 			_, err := UnmarshalPayload([]byte(tt.payload))
 			if err == nil {
 				t.Errorf("expected error for %s", tt.name)
+			} else if !contains(err.Error(), tt.errMsg) {
+				t.Errorf("expected error containing %q, got: %v", tt.errMsg, err)
 			}
 		})
 	}

--- a/pkg/modelartifact/payload.go
+++ b/pkg/modelartifact/payload.go
@@ -104,10 +104,18 @@ func MarshalPayload(m *manifest.Manifest) ([]byte, error) {
 // Validates the root digest against the resource digests. Handles both
 // v1.0 and v0.2 (compat) predicate formats.
 func UnmarshalPayload(data []byte) (*manifest.Manifest, error) {
-	// Parse JSON into a generic map for flexible handling
 	var dssePayload map[string]interface{}
 	if err := json.Unmarshal(data, &dssePayload); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal payload JSON: %w", err)
+	}
+
+	// Validate _type field (spec §8.3)
+	stmtType, ok := dssePayload["_type"].(string)
+	if !ok {
+		return nil, fmt.Errorf("_type field missing or not a string")
+	}
+	if stmtType != utils.InTotoStatementType {
+		return nil, fmt.Errorf("unsupported statement type: expected %s, got %s", utils.InTotoStatementType, stmtType)
 	}
 
 	predicateType, ok := dssePayload["predicateType"].(string)


### PR DESCRIPTION
## Summary

- Add validation of the `_type` field in `UnmarshalPayload` to ensure it equals `https://in-toto.io/Statement/v1` before processing
- Previously, only `predicateType` was validated — a payload with an incorrect statement type (e.g. `v0`) would be silently accepted
- Implements OMS spec §8.3: *"`_type` MUST be `https://in-toto.io/Statement/v1`"*

Closes #118

## Test plan

- [x] `TestUnmarshalPayloadInvalid/missing__type` — rejects payload without `_type`
- [x] `TestUnmarshalPayloadInvalid/wrong__type` — rejects `v0` statement type
- [x] `TestUnmarshalPayloadInvalid/missing_predicateType` — still rejects after `_type` passes
- [x] `TestUnmarshalPayloadInvalid/wrong_predicateType` — still rejects wrong predicate
- [x] `TestMarshalPayloadFormat` — round-trip still works
- [x] Full test suite passes
- [x] Linter passes
