### PR TITLE
Always exclude git paths during canonicalization

### DIFF
--- a/pkg/modelartifact/modelartifact.go
+++ b/pkg/modelartifact/modelartifact.go
@@ -182,9 +182,10 @@ func buildHashingConfig(opts Options) *config.HashingConfig {
 		hc.UseFileSerialization(hashAlgorithm, opts.AllowSymlinks, opts.IgnorePaths)
 	}
 
-	if opts.IgnoreGitPaths {
-		hc.SetIgnoredPaths(opts.IgnorePaths, true)
-	}
+	// Git paths (.git, .gitignore, .gitattributes, .github, .gitmodules)
+	// are always excluded per spec §6.2. The IgnoreGitPaths field is
+	// kept for backward compatibility but no longer controls this.
+	hc.SetIgnoredPaths(opts.IgnorePaths, true)
 
 	if opts.Logger != nil {
 		hc.SetLogger(opts.Logger)

--- a/pkg/modelartifact/modelartifact_test.go
+++ b/pkg/modelartifact/modelartifact_test.go
@@ -454,6 +454,40 @@ func TestUnmarshalPayloadInvalid(t *testing.T) {
 	}
 }
 
+func TestCanonicalizeDefaultExcludesGitPaths(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "model.bin"), []byte("weights"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("*.log"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".gitattributes"), []byte("* text=auto"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".git", "HEAD"), []byte("ref: refs/heads/main"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Use default Options{} — git paths must still be excluded (spec §6.2)
+	m, err := Canonicalize(dir, Options{})
+	if err != nil {
+		t.Fatalf("Canonicalize failed: %v", err)
+	}
+
+	descs := m.ResourceDescriptors()
+	if len(descs) != 1 {
+		t.Fatalf("expected 1 descriptor (model.bin only), got %d", len(descs))
+	}
+	if descs[0].Identifier != "model.bin" {
+		t.Errorf("expected model.bin, got %s", descs[0].Identifier)
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && searchString(s, substr)
 }

--- a/pkg/modelartifact/options.go
+++ b/pkg/modelartifact/options.go
@@ -48,8 +48,9 @@ type Options struct {
 	// Paths can be absolute or relative to the model root.
 	IgnorePaths []string
 
-	// IgnoreGitPaths automatically excludes .git, .gitignore, .gitattributes,
-	// .github, and .gitmodules from canonicalization.
+	// IgnoreGitPaths is retained for backward compatibility but has no effect.
+	// Git paths (.git, .gitignore, .gitattributes, .github, .gitmodules) are
+	// always excluded per OMS spec §6.2.
 	IgnoreGitPaths bool
 
 	// AllowSymlinks follows symbolic links instead of skipping them.


### PR DESCRIPTION
## Summary

- `buildHashingConfig` now always applies git path exclusions (`.git`, `.gitignore`, `.gitattributes`, `.github`, `.gitmodules`) regardless of `IgnoreGitPaths`
- Previously, library callers using `Options{}` got `IgnoreGitPaths=false` (Go zero value), so git paths were included in the manifest — violating OMS spec §6.2
- The CLI was already correct (it defaults `--ignore-git-paths` to `true`), so this only affects direct library callers
- `IgnoreGitPaths` field is retained for backward compatibility but is now a no-op

Closes #120

## Test plan

- [x] `TestCanonicalizeDefaultExcludesGitPaths` — verifies `Options{}` excludes `.git`, `.gitignore`, `.gitattributes`
- [x] Full test suite passes
- [x] Linter passes
- [x] Hardening tests pass
