### PR TITLE
Omit zero-byte files from shard serialization

### DIFF
--- a/pkg/config/hashing_config.go
+++ b/pkg/config/hashing_config.go
@@ -458,18 +458,18 @@ func (c *HashingConfig) hashFilesWithShards(modelPath string, filePaths []string
 			return nil, fmt.Errorf("%w: %q", ErrInvalidUTF8Path, relPath)
 		}
 
-		// Get file size
 		fileInfo, err := os.Stat(filePath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to stat %s: %w", filePath, err)
 		}
 		fileSize := fileInfo.Size()
 
-		// Calculate number of shards (at least 1 for empty files)
-		numShards := (fileSize + c.shardSize - 1) / c.shardSize
-		if numShards == 0 {
-			numShards = 1 // Empty files produce one shard with empty content
+		// Zero-byte files are omitted from resources (spec §6.3.2)
+		if fileSize == 0 {
+			continue
 		}
+
+		numShards := (fileSize + c.shardSize - 1) / c.shardSize
 
 		// Hash each shard
 		for i := int64(0); i < numShards; i++ {

--- a/pkg/config/hashing_config_test.go
+++ b/pkg/config/hashing_config_test.go
@@ -901,6 +901,33 @@ func TestHashShards_InvalidUTF8PathRejected(t *testing.T) {
 	}
 }
 
+func TestHashShards_EmptyFileOmitted(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "data.bin"), []byte("content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "empty.bin"), []byte{}, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	hc := NewHashingConfig()
+	hc.UseShardSerialization("sha256", 16, false, nil)
+
+	m, err := hc.Hash(dir, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, d := range m.ResourceDescriptors() {
+		if strings.Contains(d.Identifier, "empty") {
+			t.Errorf("zero-byte file should be omitted from shard manifest, got: %s", d.Identifier)
+		}
+	}
+	if len(m.ResourceDescriptors()) != 1 {
+		t.Fatalf("expected 1 descriptor (data.bin only), got %d", len(m.ResourceDescriptors()))
+	}
+}
+
 func TestHashFiles_ValidUTF8PathAccepted(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "日本語.txt"), []byte("unicode"), 0644); err != nil {


### PR DESCRIPTION
## Summary

- Skip zero-byte files in `hashFilesWithShards` instead of creating a shard with `start=0, end=0`
- The old code set `numShards=1` for empty files, violating spec §6.3.2 ("Files with zero bytes MUST be omitted from resources") and would panic at runtime since the sharded file hasher requires `end > start`

Closes #121

## Test plan

- [x] `TestHashShards_EmptyFileOmitted` — verifies zero-byte file is excluded from shard manifest
- [x] Full test suite passes
- [x] Linter passes
