### PR TITLE
Fix shard name parser to handle colons in file paths

### DIFF
--- a/pkg/manifest/manifest_item.go
+++ b/pkg/manifest/manifest_item.go
@@ -111,26 +111,31 @@ func (item *ShardedFileManifestItem) Digest() digests.Digest {
 
 // parseShardName parses a shard identifier of the form "path:start:end".
 //
-// Returns the path, start offset, end offset, and an error if the format is
-// invalid or the numeric values cannot be parsed.
+// Per spec §6.3.2, filenames may contain colons, so the parser matches
+// the last two colon-separated decimal integer components as the byte range.
 func parseShardName(name string) (path string, start, end int64, err error) {
-	parts := strings.Split(name, ":")
-	if len(parts) != 3 {
-		err = fmt.Errorf("invalid resource name: expected 3 components separated by `:`, got %q", name)
+	lastColon := strings.LastIndex(name, ":")
+	if lastColon <= 0 {
+		err = fmt.Errorf("invalid shard name: missing byte range suffix in %q", name)
+		return
+	}
+	secondLastColon := strings.LastIndex(name[:lastColon], ":")
+	if secondLastColon <= 0 {
+		err = fmt.Errorf("invalid shard name: missing byte range suffix in %q", name)
 		return
 	}
 
-	path = parts[0]
+	path = name[:secondLastColon]
 
-	start, err = strconv.ParseInt(parts[1], 10, 64)
+	start, err = strconv.ParseInt(name[secondLastColon+1:lastColon], 10, 64)
 	if err != nil {
-		err = fmt.Errorf("invalid shard start %q: %w", parts[1], err)
+		err = fmt.Errorf("invalid shard start %q: %w", name[secondLastColon+1:lastColon], err)
 		return
 	}
 
-	end, err = strconv.ParseInt(parts[2], 10, 64)
+	end, err = strconv.ParseInt(name[lastColon+1:], 10, 64)
 	if err != nil {
-		err = fmt.Errorf("invalid shard end %q: %w", parts[2], err)
+		err = fmt.Errorf("invalid shard end %q: %w", name[lastColon+1:], err)
 		return
 	}
 

--- a/pkg/manifest/manifest_item_test.go
+++ b/pkg/manifest/manifest_item_test.go
@@ -101,6 +101,56 @@ func TestParseShardNameInvalid(t *testing.T) {
 	}
 }
 
+func TestParseShardNameWithColonsInPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantPath  string
+		wantStart int64
+		wantEnd   int64
+	}{
+		{
+			name:      "single colon in path",
+			input:     "file:with:colon:0:1024",
+			wantPath:  "file:with:colon",
+			wantStart: 0,
+			wantEnd:   1024,
+		},
+		{
+			name:      "multiple colons in path",
+			input:     "a:b:c:d:100:200",
+			wantPath:  "a:b:c:d",
+			wantStart: 100,
+			wantEnd:   200,
+		},
+		{
+			name:      "colon at start of path",
+			input:     ":leading:50:75",
+			wantPath:  ":leading",
+			wantStart: 50,
+			wantEnd:   75,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, start, end, err := parseShardName(tt.input)
+			if err != nil {
+				t.Fatalf("parseShardName(%q) unexpected error: %v", tt.input, err)
+			}
+			if path != tt.wantPath {
+				t.Errorf("path = %q, want %q", path, tt.wantPath)
+			}
+			if start != tt.wantStart {
+				t.Errorf("start = %d, want %d", start, tt.wantStart)
+			}
+			if end != tt.wantEnd {
+				t.Errorf("end = %d, want %d", end, tt.wantEnd)
+			}
+		})
+	}
+}
+
 func TestShardedFileManifestItemRoundTripName(t *testing.T) {
 	d := digests.NewDigest("sha256", []byte{0xAB})
 	item := NewShardedFileManifestItem("foo/bar.bin", 0, 4096, d)


### PR DESCRIPTION
## Summary

- Rewrite `parseShardName` to use `strings.LastIndex` to find the last two colons, treating everything before them as the file path
- Previously used `strings.Split(name, ":")` expecting exactly 3 parts, which broke on filenames containing colons (e.g. `file:with:colon:0:1024`)
- Implements spec §6.3.2: *"parsers MUST identify the byte-range suffix by matching the last two colon-separated decimal integer components"*

Closes #122

## Test plan

- [x] `TestParseShardNameValid` — existing simple path still works
- [x] `TestParseShardNameInvalid` — existing invalid inputs still rejected
- [x] `TestParseShardNameWithColonsInPath` — single colon, multiple colons, and leading colon in path all parse correctly
- [x] `TestShardedFileManifestItemRoundTripName` — existing round-trip test
- [x] Full test suite passes
- [x] Linter passes
