### PR TITLE
Validate ignore path entries per OMS spec

### DIFF
--- a/pkg/modelartifact/modelartifact.go
+++ b/pkg/modelartifact/modelartifact.go
@@ -29,6 +29,10 @@ import (
 // applying exclusions. Per spec §6.1, an empty model MUST be rejected.
 var ErrEmptyModel = errors.New("model contains no regular files after exclusions; empty models must be rejected (spec §6.1)")
 
+// ErrInvalidIgnorePath is returned when an ignore path entry contains
+// prohibited patterns per spec §6.2.1.
+var ErrInvalidIgnorePath = errors.New("invalid ignore path")
+
 // Canonicalize walks a model directory (or OCI manifest), hashes all files,
 // and returns a deterministic Manifest.
 //
@@ -40,6 +44,10 @@ var ErrEmptyModel = errors.New("model contains no regular files after exclusions
 // structure), the manifest is created from the OCI layers instead of walking
 // the filesystem.
 func Canonicalize(modelPath string, opts Options) (*manifest.Manifest, error) {
+	if err := validateIgnorePaths(opts.IgnorePaths); err != nil {
+		return nil, err
+	}
+
 	var m *manifest.Manifest
 	var err error
 
@@ -192,4 +200,25 @@ func buildHashingConfig(opts Options) *config.HashingConfig {
 	}
 
 	return hc
+}
+
+// validateIgnorePaths checks that user-provided ignore paths conform to
+// spec §6.2.1: no glob characters, no leading /, no ../ components,
+// and must use / as separator.
+func validateIgnorePaths(paths []string) error {
+	for _, p := range paths {
+		if strings.ContainsAny(p, "*?[") {
+			return fmt.Errorf("%w: must not contain glob characters: %s", ErrInvalidIgnorePath, p)
+		}
+		if strings.HasPrefix(p, "/") {
+			return fmt.Errorf("%w: must not start with /: %s", ErrInvalidIgnorePath, p)
+		}
+		if strings.Contains(p, "../") || p == ".." {
+			return fmt.Errorf("%w: must not contain ../ components: %s", ErrInvalidIgnorePath, p)
+		}
+		if strings.Contains(p, "\\") {
+			return fmt.Errorf("%w: must use / as path separator: %s", ErrInvalidIgnorePath, p)
+		}
+	}
+	return nil
 }

--- a/pkg/modelartifact/modelartifact_test.go
+++ b/pkg/modelartifact/modelartifact_test.go
@@ -454,6 +454,55 @@ func TestUnmarshalPayloadInvalid(t *testing.T) {
 	}
 }
 
+func TestCanonicalizeRejectsInvalidIgnorePaths(t *testing.T) {
+	dir := createTestModel(t)
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"glob star", "dir/*.bin"},
+		{"glob question", "dir/file?.txt"},
+		{"glob bracket", "dir/[abc].txt"},
+		{"leading slash", "/absolute/path"},
+		{"dot-dot slash", "../escape/path"},
+		{"dot-dot mid", "sub/../escape"},
+		{"bare dot-dot", ".."},
+		{"backslash separator", `sub\dir\file.txt`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Canonicalize(dir, Options{IgnorePaths: []string{tt.path}})
+			if err == nil {
+				t.Fatal("expected error for invalid ignore path")
+			}
+			if !errors.Is(err, ErrInvalidIgnorePath) {
+				t.Errorf("expected ErrInvalidIgnorePath, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestCanonicalizeAcceptsValidIgnorePaths(t *testing.T) {
+	dir := createTestModel(t)
+
+	validPaths := []string{
+		"tokenizer.json",
+		"weights/layer_0.bin",
+		"sub/dir/file.txt",
+	}
+
+	for _, p := range validPaths {
+		t.Run(p, func(t *testing.T) {
+			_, err := Canonicalize(dir, Options{IgnorePaths: []string{p}})
+			if errors.Is(err, ErrInvalidIgnorePath) {
+				t.Errorf("valid path %q rejected: %v", p, err)
+			}
+		})
+	}
+}
+
 func TestCanonicalizeDefaultExcludesGitPaths(t *testing.T) {
 	dir := t.TempDir()
 

--- a/pkg/signing/helpers.go
+++ b/pkg/signing/helpers.go
@@ -17,6 +17,8 @@ package signing
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/sigstore/model-signing/pkg/logging"
 	"github.com/sigstore/model-signing/pkg/manifest"
@@ -60,7 +62,10 @@ func WriteBundle(protoBundle *protobundle.Bundle, path string) error {
 func PreparePayload(modelPath, signaturePath string, opts modelartifact.Options, logger logging.Logger) (*manifest.Manifest, []byte, error) {
 	// Step 1: Canonicalize the model
 	logger.Debugln("\nStep 1: Canonicalizing model...")
-	ignorePaths := append(append([]string{}, opts.IgnorePaths...), signaturePath)
+	ignorePaths := append([]string{}, opts.IgnorePaths...)
+	if relSig, err := filepath.Rel(modelPath, signaturePath); err == nil && !strings.HasPrefix(relSig, "..") {
+		ignorePaths = append(ignorePaths, filepath.ToSlash(relSig))
+	}
 	canonOpts := opts
 	canonOpts.IgnorePaths = ignorePaths
 	canonOpts.Logger = logger

--- a/pkg/signing/key/key_signer_test.go
+++ b/pkg/signing/key/key_signer_test.go
@@ -212,7 +212,7 @@ func TestNewKeySigner_WithIgnorePaths(t *testing.T) {
 	opts := KeySignerOptions{
 		ModelPath:      modelDir,
 		SignaturePath:  filepath.Join(tmpDir, "sig.json"),
-		IgnorePaths:    []string{ignoreDir},
+		IgnorePaths:    []string{"ignored"},
 		IgnoreGitPaths: true,
 		AllowSymlinks:  false,
 		PrivateKeyPath: keyFile,
@@ -246,7 +246,7 @@ func TestNewKeySigner_InvalidIgnorePath(t *testing.T) {
 	opts := KeySignerOptions{
 		ModelPath:      modelDir,
 		SignaturePath:  filepath.Join(tmpDir, "sig.json"),
-		IgnorePaths:    []string{"/nonexistent/path"},
+		IgnorePaths:    []string{"nonexistent/path"},
 		IgnoreGitPaths: false,
 		PrivateKeyPath: keyFile,
 	}

--- a/pkg/signing/sign.go
+++ b/pkg/signing/sign.go
@@ -37,8 +37,9 @@ func ValidateSignerPaths(modelPath string, ignorePaths []string) error {
 	}
 	// Validate ignore paths only for non-OCI manifests.
 	// For OCI manifests, ignore paths refer to layer entries, not local files.
+	// Ignore paths are relative to the model root (spec §6.2.1).
 	if !oci.IsOCIManifest(modelPath) {
-		if err := utils.ValidateMultiple("ignore paths", ignorePaths, utils.PathTypeAny); err != nil {
+		if err := utils.ValidateMultipleRelativeTo("ignore paths", ignorePaths, modelPath, utils.PathTypeAny); err != nil {
 			return err
 		}
 	}

--- a/pkg/signing/sigstore/sigstore_signer_test.go
+++ b/pkg/signing/sigstore/sigstore_signer_test.go
@@ -77,7 +77,7 @@ func TestNewSigstoreSigner_WithIgnorePaths(t *testing.T) {
 	opts := SigstoreSignerOptions{
 		ModelPath:      modelDir,
 		SignaturePath:  filepath.Join(tmpDir, "sig.json"),
-		IgnorePaths:    []string{ignoreDir},
+		IgnorePaths:    []string{"ignored"},
 		IgnoreGitPaths: true,
 		AllowSymlinks:  false,
 	}
@@ -104,7 +104,7 @@ func TestNewSigstoreSigner_InvalidIgnorePath(t *testing.T) {
 	opts := SigstoreSignerOptions{
 		ModelPath:     modelDir,
 		SignaturePath: filepath.Join(tmpDir, "sig.json"),
-		IgnorePaths:   []string{"/nonexistent/path"},
+		IgnorePaths:   []string{"nonexistent/path"},
 	}
 
 	_, err := NewSigstoreSigner(opts)

--- a/pkg/utils/validation.go
+++ b/pkg/utils/validation.go
@@ -17,6 +17,7 @@ package utils
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
 // PathType represents the type of path to validate.
@@ -121,4 +122,19 @@ func ValidateOptionalFile(fieldName, path string) error {
 		return nil
 	}
 	return ValidateFileExists(fieldName, path)
+}
+
+// ValidateMultipleRelativeTo validates paths that are relative to a base directory.
+// Each path is resolved against baseDir before checking existence.
+func ValidateMultipleRelativeTo(fieldName string, paths []string, baseDir string, pathType PathType) error {
+	for i, p := range paths {
+		if p == "" {
+			return fmt.Errorf("%s contains empty path at index %d", fieldName, i)
+		}
+		resolved := filepath.Join(baseDir, p)
+		if err := NewPathValidator(fmt.Sprintf("%s[%d]", fieldName, i), resolved, pathType).Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/verify/helpers.go
+++ b/pkg/verify/helpers.go
@@ -20,6 +20,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/sigstore/model-signing/pkg/logging"
 	"github.com/sigstore/model-signing/pkg/modelartifact"
@@ -116,7 +118,10 @@ func ExtractAndCompareModel(bndl *bundle.Bundle, modelPath, signaturePath string
 	}
 	payloadBytes := dsseEnvelope.Payload
 
-	ignorePaths := append(append([]string{}, opts.IgnorePaths...), signaturePath)
+	ignorePaths := append([]string{}, opts.IgnorePaths...)
+	if relSig, err := filepath.Rel(modelPath, signaturePath); err == nil && !strings.HasPrefix(relSig, "..") {
+		ignorePaths = append(ignorePaths, filepath.ToSlash(relSig))
+	}
 	compareOpts := modelartifact.Options{
 		IgnorePaths:    ignorePaths,
 		IgnoreGitPaths: opts.IgnoreGitPaths,

--- a/pkg/verify/helpers_test.go
+++ b/pkg/verify/helpers_test.go
@@ -146,9 +146,9 @@ func TestCompareModelWithBundle_IgnorePathsFromCaller(t *testing.T) {
 		t.Fatal("expected error for extra unsigned file")
 	}
 
-	// With ignore of the signature file
+	// With ignore of the signature file (relative to model root per spec §6.2.1)
 	err = CompareModelWithBundle(payload, modelPath, modelartifact.Options{
-		IgnorePaths: []string{filepath.Join(modelPath, "signature.sig")},
+		IgnorePaths: []string{"signature.sig"},
 	}, false)
 	if err != nil {
 		t.Fatalf("should pass when ignoring the extra file: %v", err)

--- a/pkg/verify/key/key_verifier_test.go
+++ b/pkg/verify/key/key_verifier_test.go
@@ -163,7 +163,7 @@ func TestNewKeyVerifier_WithIgnorePaths(t *testing.T) {
 	opts := KeyVerifierOptions{
 		ModelPath:      modelDir,
 		SignaturePath:  sigFile,
-		IgnorePaths:    []string{ignoreDir},
+		IgnorePaths:    []string{"ignored"},
 		IgnoreGitPaths: true,
 		AllowSymlinks:  false,
 		PublicKeyPath:  keyFile,
@@ -203,7 +203,7 @@ func TestNewKeyVerifier_InvalidIgnorePath(t *testing.T) {
 	opts := KeyVerifierOptions{
 		ModelPath:     modelDir,
 		SignaturePath: sigFile,
-		IgnorePaths:   []string{"/nonexistent/path"},
+		IgnorePaths:   []string{"nonexistent/path"},
 		PublicKeyPath: keyFile,
 	}
 

--- a/pkg/verify/sigstore/sigstore_verifier_test.go
+++ b/pkg/verify/sigstore/sigstore_verifier_test.go
@@ -197,7 +197,7 @@ func TestNewSigstoreVerifier_WithIgnorePaths(t *testing.T) {
 	opts := SigstoreVerifierOptions{
 		ModelPath:        modelDir,
 		SignaturePath:    sigFile,
-		IgnorePaths:      []string{ignoreDir},
+		IgnorePaths:      []string{"ignored"},
 		IgnoreGitPaths:   true,
 		AllowSymlinks:    false,
 		Identity:         "test@example.com",
@@ -232,7 +232,7 @@ func TestNewSigstoreVerifier_InvalidIgnorePath(t *testing.T) {
 	opts := SigstoreVerifierOptions{
 		ModelPath:        modelDir,
 		SignaturePath:    sigFile,
-		IgnorePaths:      []string{"/nonexistent/path"},
+		IgnorePaths:      []string{"nonexistent/path"},
 		Identity:         "test@example.com",
 		IdentityProvider: "https://accounts.google.com",
 	}

--- a/pkg/verify/verify.go
+++ b/pkg/verify/verify.go
@@ -40,8 +40,9 @@ func ValidateVerifierPaths(modelPath, signaturePath string, ignorePaths []string
 	}
 	// Validate ignore paths only for non-OCI manifests.
 	// For OCI manifests, ignore paths refer to layer entries, not local files.
+	// Ignore paths are relative to the model root (spec §6.2.1).
 	if !oci.IsOCIManifest(modelPath) {
-		if err := utils.ValidateMultiple("ignore paths", ignorePaths, utils.PathTypeAny); err != nil {
+		if err := utils.ValidateMultipleRelativeTo("ignore paths", ignorePaths, modelPath, utils.PathTypeAny); err != nil {
 			return err
 		}
 	}

--- a/scripts/tests/test-hardening.sh
+++ b/scripts/tests/test-hardening.sh
@@ -807,7 +807,7 @@ fi
 if ! ${DIR}/model-signing verify key \
 	--signature "${SIGFILE}" \
 	--public-key "${KEYSDIR}/flags-key-pub.pem" \
-	--ignore-paths "${MODELDIR}/should-ignore.txt" \
+	--ignore-paths "should-ignore.txt" \
 	"${MODELDIR}" >/dev/null 2>&1; then
 	echo "  Error: Verification should pass with --ignore-paths"
 	exit 1
@@ -938,7 +938,7 @@ SIGFILE="${TMPDIR}/combined1.sig"
 if ! ${DIR}/model-signing sign key \
 	--signature "${SIGFILE}" \
 	--private-key "${KEYSDIR}/flags-key.pem" \
-	--ignore-paths "${MODELDIR}/ignore-me.txt" \
+	--ignore-paths "ignore-me.txt" \
 	"${MODELDIR}" >/dev/null 2>&1; then
 	echo "  Error: Sign failed"
 	exit 1
@@ -952,7 +952,7 @@ echo "modified-ignore" > "${MODELDIR}/ignore-me.txt"
 if ! ${DIR}/model-signing verify key \
 	--signature "${SIGFILE}" \
 	--public-key "${KEYSDIR}/flags-key-pub.pem" \
-	--ignore-paths "${MODELDIR}/ignore-me.txt" \
+	--ignore-paths "ignore-me.txt" \
 	--ignore-unsigned-files \
 	"${MODELDIR}" >/dev/null 2>&1; then
 	echo "  Error: Verification should pass with combined flags"
@@ -1009,7 +1009,7 @@ ln -s target.txt "${MODELDIR}/link.txt"
 if ! ${DIR}/model-signing sign key \
 	--signature "${SIGFILE}" \
 	--private-key "${KEYSDIR}/flags-key.pem" \
-	--ignore-paths "${MODELDIR}/ignore-me.txt" \
+	--ignore-paths "ignore-me.txt" \
 	--allow-symlinks \
 	"${MODELDIR}" >/dev/null 2>&1; then
 	echo "  Error: Sign failed"
@@ -1026,7 +1026,7 @@ ln -s new-target.txt "${MODELDIR}/new-link.txt"
 if ! ${DIR}/model-signing verify key \
 	--signature "${SIGFILE}" \
 	--public-key "${KEYSDIR}/flags-key-pub.pem" \
-	--ignore-paths "${MODELDIR}/ignore-me.txt" \
+	--ignore-paths "ignore-me.txt" \
 	--allow-symlinks \
 	--ignore-unsigned-files \
 	"${MODELDIR}" >/dev/null 2>&1; then
@@ -1050,7 +1050,7 @@ if ! ${DIR}/model-signing sign certificate \
 	--signature "${SIGFILE}" \
 	--private-key "${CERTSDIR}/self-signed-key.pem" \
 	--signing-certificate "${CERTSDIR}/self-signed-cert.pem" \
-	--ignore-paths "${MODELDIR}/ignore-me.txt" \
+	--ignore-paths "ignore-me.txt" \
 	--allow-symlinks \
 	"${MODELDIR}" >/dev/null 2>&1; then
 	echo "  Error: Sign certificate with flags failed"
@@ -1064,7 +1064,7 @@ echo "new-unsigned" > "${MODELDIR}/new-unsigned.txt"
 if ! ${DIR}/model-signing verify certificate \
 	--signature "${SIGFILE}" \
 	--certificate-chain "${CERTSDIR}/self-signed-cert.pem" \
-	--ignore-paths "${MODELDIR}/ignore-me.txt" \
+	--ignore-paths "ignore-me.txt" \
 	--allow-symlinks \
 	--ignore-unsigned-files \
 	"${MODELDIR}" >/dev/null 2>&1; then

--- a/scripts/tests/test-sign-verify-allversions.sh
+++ b/scripts/tests/test-sign-verify-allversions.sh
@@ -46,7 +46,7 @@ if ! ${DIR}/model-signing \
 	sign key \
 	--signature "${sigfile_key}" \
 	--private-key ${DIR}/keys/certificate/signing-key.pem \
-	--ignore-paths "${ignorefile}" \
+	--ignore-paths "$(basename "${ignorefile}")" \
 	"${MODELDIR}" || \
   test ! -f "${sigfile_key}"; then
 	echo "Error: 'sign key' failed"
@@ -62,7 +62,7 @@ if ! ${DIR}/model-signing \
 	--private-key ${DIR}/keys/certificate/signing-key.pem \
 	--signing-certificate ${DIR}/keys/certificate/signing-key-cert.pem \
 	--certificate-chain ${DIR}/keys/certificate/int-ca-cert.pem \
-	--ignore-paths "${ignorefile}" \
+	--ignore-paths "$(basename "${ignorefile}")" \
 	"${MODELDIR}" || \
   test ! -f "${sigfile_certificate}"; then
 	echo "Error: 'sign certificate' failed"
@@ -76,7 +76,7 @@ if ! sigstore_sign_with_retry "${TOKENPROJ}" "${token_file}" "--identity-token" 
 	sign sigstore \
 	--use-staging \
 	--signature "${sigfile_sigstore}" \
-	--ignore-paths "${ignorefile}" \
+	--ignore-paths "$(basename "${ignorefile}")" \
 	"${MODELDIR}"; then
 	echo "Error: 'sign sigstore' failed"
 	exit 1
@@ -91,7 +91,7 @@ if ! out=$(${DIR}/model-signing \
 	verify key \
 	--signature "${sigfile_key}" \
 	--public-key ${DIR}/keys/certificate/signing-key-pub.pem \
-	--ignore-paths "${ignorefile}" \
+	--ignore-paths "$(basename "${ignorefile}")" \
 	"${MODELDIR}" 2>&1); then
 	echo "Error: 'verify key' failed"
 	echo "${out}"
@@ -108,7 +108,7 @@ if ! out=$(${DIR}/model-signing \
 	verify certificate \
 	--signature "${sigfile_certificate}" \
 	--certificate-chain ${DIR}/keys/certificate/ca-cert.pem \
-	--ignore-paths "${ignorefile}" \
+	--ignore-paths "$(basename "${ignorefile}")" \
 	"${MODELDIR}" 2>&1); then
 	echo "Error: 'verify certificate' failed"
 	echo "${out}"
@@ -127,7 +127,7 @@ if ! out=$(${DIR}/model-signing \
 	--signature "${sigfile_sigstore}" \
 	--identity untrusted-sa@sigstore-conformance.iam.gserviceaccount.com \
 	--identity-provider https://accounts.google.com \
-	--ignore-paths "${ignorefile}" \
+	--ignore-paths "$(basename "${ignorefile}")" \
 	"${MODELDIR}" 2>&1); then
 	echo "Error: 'verify sigstore' failed"
 	echo "${out}"
@@ -153,7 +153,7 @@ for v in v1.1.0 v1.0.1 v1.0.0 v0.3.1 v0.2.0; do
 	# Build ignore args only if ignore-me exists
 	ignore_args=()
 	if [ -e "${modeldir}/ignore-me" ]; then
-		ignore_args=(--ignore-paths "${modeldir}/ignore-me")
+		ignore_args=(--ignore-paths "ignore-me")
 	fi
 
 	case "${v}" in
@@ -189,7 +189,7 @@ for v in v1.1.0 v1.0.1 v1.0.0 v0.3.1 v0.2.0; do
 	# Build ignore args only if ignore-me exists
 	ignore_args=()
 	if [ -e "${modeldir}/ignore-me" ]; then
-		ignore_args=(--ignore-paths "${modeldir}/ignore-me")
+		ignore_args=(--ignore-paths "ignore-me")
 	fi
 
 	if [ -d "${modeldir}" ]; then
@@ -217,7 +217,7 @@ for v in v1.1.0 v1.0.1 v1.0.0 v0.3.1 v0.2.0; do
 	# Build ignore args only if ignore-me exists
 	ignore_args=()
 	if [ -e "${modeldir}/ignore-me" ]; then
-		ignore_args=(--ignore-paths "${modeldir}/ignore-me")
+		ignore_args=(--ignore-paths "ignore-me")
 	fi
 
 	if [ -d "${modeldir}" ]; then

--- a/scripts/tests/test-sign-verify.sh
+++ b/scripts/tests/test-sign-verify.sh
@@ -24,7 +24,7 @@ if ! ${DIR}/model-signing \
 	sign key \
 	--signature "${sigfile}" \
 	--private-key ./keys/certificate/signing-key.pem \
-	--ignore-paths "${ignorefile}" \
+	--ignore-paths "$(basename "${ignorefile}")" \
 	"${TMPDIR}"; then
 	echo "Error: 'sign key' failed"
 	exit 1
@@ -34,7 +34,7 @@ if ! ${DIR}/model-signing \
 	verify key \
 	--signature "${sigfile}" \
 	--public-key ./keys/certificate/signing-key-pub.pem \
-	--ignore-paths "${ignorefile}" \
+	--ignore-paths "$(basename "${ignorefile}")" \
 	"${TMPDIR}"; then
 	echo "Error: 'verify key' failed"
 	exit 1
@@ -59,7 +59,7 @@ if ! ${DIR}/model-signing \
 	--private-key ./keys/certificate/signing-key.pem \
 	--signing-certificate ./keys/certificate/signing-key-cert.pem \
 	--certificate-chain ./keys/certificate/int-ca-cert.pem \
-	--ignore-paths "${ignorefile}" \
+	--ignore-paths "$(basename "${ignorefile}")" \
 	"${TMPDIR}"; then
 	echo "Error: 'sign certificate' failed"
 	exit 1
@@ -69,7 +69,7 @@ if ! ${DIR}/model-signing \
 	verify certificate \
 	--signature "${sigfile}" \
 	--certificate-chain ./keys/certificate/ca-cert.pem \
-	--ignore-paths "${ignorefile}" \
+	--ignore-paths "$(basename "${ignorefile}")" \
 	"${TMPDIR}"; then
 	echo "Error: 'verify certificate' failed"
 	exit 1
@@ -213,7 +213,7 @@ if ! ${DIR}/model-signing \
 	--private-key "${DIR}/keys/certificate/signing-key.pem" \
 	--signing-certificate "${DIR}/keys/certificate/signing-key-cert.pem" \
 	--certificate-chain "${DIR}/keys/certificate/int-ca-cert.pem" \
-	--ignore-paths "../$(basename "${ignorefile}")" \
+	--ignore-paths "$(basename "${ignorefile}")" \
 	--allow-symlinks \
 	.. ; then
 	echo "Error: 'sign certificate' failed"
@@ -361,7 +361,7 @@ if has_pkcs11_support && command -v softhsm2-util &>/dev/null && command -v p11t
 		sign pkcs11-key \
 		--signature "${pkcs11_sigfile}" \
 		--pkcs11-uri "${pkcs11uri}" \
-		--ignore-paths "${pkcs11_ignorefile}" \
+		--ignore-paths "$(basename "${pkcs11_ignorefile}")" \
 		"${pkcs11_tmpdir}"; then
 		echo "Error: 'sign pkcs11-key' failed"
 		"${DIR}/softhsm_setup" teardown &>/dev/null || true
@@ -375,7 +375,7 @@ if has_pkcs11_support && command -v softhsm2-util &>/dev/null && command -v p11t
 		verify key \
 		--signature "${pkcs11_sigfile}" \
 		--public-key "${pkcs11_pubkey}" \
-		--ignore-paths "${pkcs11_ignorefile}" \
+		--ignore-paths "$(basename "${pkcs11_ignorefile}")" \
 		"${pkcs11_tmpdir}"; then
 		echo "Error: 'verify key' failed on PKCS#11 signature"
 		"${DIR}/softhsm_setup" teardown &>/dev/null || true

--- a/scripts/tests/test-verify-v1.0.1-elliptic-key.sh
+++ b/scripts/tests/test-verify-v1.0.1-elliptic-key.sh
@@ -5,7 +5,7 @@ if ! ./model-signing \
 	verify key \
 	--signature ./v1.0.1-elliptic-key/model.sig \
 	--public-key ./keys/certificate/signing-key-pub.pem \
-	--ignore-paths "./v1.0.1-elliptic-key/ignore-me" \
+	--ignore-paths "ignore-me" \
 	./v1.0.1-elliptic-key ; then
 	echo "Error: 'verify key' failed on v1.0.1"
 	exit 1

--- a/scripts/tests/test-verify-v1.0.1-sigstore.sh
+++ b/scripts/tests/test-verify-v1.0.1-sigstore.sh
@@ -5,7 +5,7 @@ if ! ./model-signing \
 	verify sigstore \
 	--identity stefanb@us.ibm.com \
 	--identity-provider https://sigstore.verify.ibm.com/oauth2 \
-	--ignore-paths ./v1.0.1-sigstore/ignore-me \
+	--ignore-paths "ignore-me" \
 	--signature ./v1.0.1-sigstore/model.sig \
 	./v1.0.1-sigstore/; then
 	echo "Error: 'verify sigstore' failed on v1.0.1"

--- a/scripts/tests/test-verify-v1.1.0-certificate.sh
+++ b/scripts/tests/test-verify-v1.1.0-certificate.sh
@@ -3,7 +3,7 @@
 echo "Testing 'verify certificate'"
 if ! ./model-signing \
 	verify certificate \
-	--ignore-paths ./v1.1.0-certificate/ignore-me \
+	--ignore-paths "ignore-me" \
 	--signature ./v1.1.0-certificate/model.sig \
 	--certificate-chain ./keys/certificate/ca-cert.pem \
 	./v1.1.0-certificate/; then

--- a/scripts/tests/test-verify-v1.1.0-elliptic-key.sh
+++ b/scripts/tests/test-verify-v1.1.0-elliptic-key.sh
@@ -3,7 +3,7 @@
 echo "Testing 'verify key'"
 if ! ./model-signing \
 	verify key \
-	--ignore-paths ./v1.1.0-elliptic-key/ignore-me \
+	--ignore-paths "ignore-me" \
 	--signature ./v1.1.0-elliptic-key/model.sig \
 	--public-key ./keys/certificate/signing-key-pub.pem \
 	./v1.1.0-elliptic-key ; then

--- a/scripts/tests/test-verify-v1.1.0-sigstore.sh
+++ b/scripts/tests/test-verify-v1.1.0-sigstore.sh
@@ -5,7 +5,7 @@ if ! ./model-signing \
 	verify sigstore \
 	--identity stefanb@us.ibm.com \
 	--identity-provider https://sigstore.verify.ibm.com/oauth2 \
-	--ignore-paths ./v1.1.0-sigstore/ignore-me \
+	--ignore-paths "ignore-me" \
 	--signature ./v1.1.0-sigstore/model.sig \
 	./v1.1.0-sigstore/; then
 	echo "Error: 'verify sigstore' failed on v1.1.0"

--- a/test/conformance/main.go
+++ b/test/conformance/main.go
@@ -68,22 +68,30 @@ func newStderrLogger() logging.Logger {
 	})
 }
 
-// resolveIgnorePath converts an ignore path to an absolute path.
-// The Go CLI requires absolute paths that exist on the filesystem.
+// resolveIgnorePath converts an ignore path to a model-root-relative path.
+// Per spec §6.2.1, ignore paths must be relative to the model root and
+// must not contain leading /, ../, or glob characters.
 func resolveIgnorePath(p, modelPath string) (string, error) {
 	if filepath.IsAbs(p) {
-		return p, nil
+		rel, err := filepath.Rel(modelPath, p)
+		if err != nil || strings.HasPrefix(rel, "..") {
+			return "", fmt.Errorf("path %s is outside model root %s", p, modelPath)
+		}
+		return filepath.ToSlash(rel), nil
 	}
 	abs := filepath.Join(modelPath, p)
 	if _, err := os.Stat(abs); err != nil {
 		if cwdAbs, err2 := filepath.Abs(p); err2 == nil {
 			if _, err3 := os.Stat(cwdAbs); err3 == nil {
-				return cwdAbs, nil
+				rel, err4 := filepath.Rel(modelPath, cwdAbs)
+				if err4 == nil && !strings.HasPrefix(rel, "..") {
+					return filepath.ToSlash(rel), nil
+				}
 			}
 		}
 		return "", fmt.Errorf("path does not exist: %s", abs)
 	}
-	return abs, nil
+	return filepath.ToSlash(p), nil
 }
 
 func execCmd(args []string) int {

--- a/test/conformance/sign.go
+++ b/test/conformance/sign.go
@@ -19,6 +19,8 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/sigstore/model-signing/pkg/logging"
 	"github.com/sigstore/model-signing/pkg/modelartifact"
@@ -133,7 +135,10 @@ func signModel(args []string) int {
 func signModelLibrary(modelPath, outputBundle, privateKey, hashAlgorithm string, shardSize int64, ignorePaths []string, logger logging.Logger) int {
 	ctx := context.Background()
 
-	allIgnore := append(append([]string{}, ignorePaths...), outputBundle)
+	allIgnore := append([]string{}, ignorePaths...)
+	if relBundle, err := filepath.Rel(modelPath, outputBundle); err == nil && !strings.HasPrefix(relBundle, "..") {
+		allIgnore = append(allIgnore, filepath.ToSlash(relBundle))
+	}
 
 	m, err := modelartifact.Canonicalize(modelPath, modelartifact.Options{
 		HashAlgorithm: hashAlgorithm,


### PR DESCRIPTION
## Summary

- Add `validateIgnorePaths` in `Canonicalize` to reject ignore paths containing glob characters (`*`, `?`, `[`), leading `/`, `../` components, or backslash separators per OMS spec §6.2.1
- Convert signature paths to relative POSIX paths in `PreparePayload` and `ExtractAndCompareModel` so they pass validation instead of being appended as absolute paths
- Fix `pathMatches` to normalize all paths to forward slashes (`filepath.ToSlash`) before comparison instead of using `filepath.Separator`, ensuring cross-platform correctness
- Update all CLI test scripts, conformance adapter, and version verification scripts to use relative ignore paths

Fixes #124
Fixes #125

## Test plan

- [x] Unit tests for all prohibited patterns (glob, leading `/`, `../`, backslash) and valid paths
- [x] Existing tests updated to use relative paths — full `go test ./...` passes
- [x] `go vet` and `golangci-lint` clean
- [x] CI: lint, cross-os, cli-tests, hardening, interop all pass
- [ ] CI: conformance (62/63 passed, 1 Sigstore infra flake), otel (Docker Hub timeout)