### PR TITLE
Reject empty resources array in payload during verification

### DIFF
--- a/pkg/modelartifact/modelartifact_test.go
+++ b/pkg/modelartifact/modelartifact_test.go
@@ -440,6 +440,7 @@ func TestUnmarshalPayloadInvalid(t *testing.T) {
 		{"wrong _type", `{"_type": "https://in-toto.io/Statement/v0", "predicateType": "x"}`, "unsupported statement type"},
 		{"missing predicateType", `{"_type": "https://in-toto.io/Statement/v1", "subject": []}`, "predicateType"},
 		{"wrong predicateType", `{"_type": "https://in-toto.io/Statement/v1", "predicateType": "wrong"}`, "predicate type mismatch"},
+		{"empty resources", `{"_type": "https://in-toto.io/Statement/v1", "predicateType": "https://model_signing/signature/v1.0", "subject": [{"name": "m", "digest": {"sha256": "abc"}}], "predicate": {"serialization": {"method": "files", "hash_type": "sha256", "allow_symlinks": false}, "resources": []}}`, "resources array must contain at least one entry"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/modelartifact/payload.go
+++ b/pkg/modelartifact/payload.go
@@ -209,6 +209,10 @@ func unmarshalPayloadV1(dssePayload map[string]interface{}) (*manifest.Manifest,
 		return nil, fmt.Errorf("resources is not an array")
 	}
 
+	if len(resources) == 0 {
+		return nil, fmt.Errorf("resources array must contain at least one entry (spec §5.2.1)")
+	}
+
 	// Reconstruct manifest items and collect digests
 	items := make([]manifest.ManifestItem, 0, len(resources))
 	digestList := make([]digests.Digest, 0, len(resources))


### PR DESCRIPTION
## Summary

- Add length check in `unmarshalPayloadV1` to reject payloads with an empty `resources` array per spec §5.2.1
- The producer side (`Canonicalize`) already rejects empty models, but a crafted payload could bypass this during verification

Fixes #126

## Test plan

- [x] New test case in `TestUnmarshalPayloadInvalid` for empty resources
- [x] Full `go test ./...` passes
- [x] `golangci-lint` clean
