### PR TITLE
Reject empty subject name in payload during verification

### DIFF
--- a/pkg/modelartifact/modelartifact_test.go
+++ b/pkg/modelartifact/modelartifact_test.go
@@ -440,6 +440,7 @@ func TestUnmarshalPayloadInvalid(t *testing.T) {
 		{"wrong _type", `{"_type": "https://in-toto.io/Statement/v0", "predicateType": "x"}`, "unsupported statement type"},
 		{"missing predicateType", `{"_type": "https://in-toto.io/Statement/v1", "subject": []}`, "predicateType"},
 		{"wrong predicateType", `{"_type": "https://in-toto.io/Statement/v1", "predicateType": "wrong"}`, "predicate type mismatch"},
+		{"empty subject name", `{"_type": "https://in-toto.io/Statement/v1", "predicateType": "https://model_signing/signature/v1.0", "subject": [{"name": "", "digest": {"sha256": "abc"}}], "predicate": {}}`, "subject name must not be empty"},
 		{"empty resources", `{"_type": "https://in-toto.io/Statement/v1", "predicateType": "https://model_signing/signature/v1.0", "subject": [{"name": "m", "digest": {"sha256": "abc"}}], "predicate": {"serialization": {"method": "files", "hash_type": "sha256", "allow_symlinks": false}, "resources": []}}`, "resources array must contain at least one entry"},
 	}
 

--- a/pkg/modelartifact/payload.go
+++ b/pkg/modelartifact/payload.go
@@ -161,6 +161,10 @@ func unmarshalPayloadV1(dssePayload map[string]interface{}) (*manifest.Manifest,
 		return nil, fmt.Errorf("subject name missing or not a string")
 	}
 
+	if modelName == "" {
+		return nil, fmt.Errorf("subject name must not be empty")
+	}
+
 	digestMap, ok := subject["digest"].(map[string]interface{})
 	if !ok {
 		return nil, fmt.Errorf("subject digest missing or not an object")


### PR DESCRIPTION
## Summary

- Add check in `unmarshalPayloadV1` to reject payloads where `subject[0].name` is an empty string, per spec §6.5

Fixes #127

## Test plan

- [x] New test case in `TestUnmarshalPayloadInvalid` for empty subject name
- [x] Full `go test ./...` passes
