### PR TITLE
Fix single-file models producing "." as resource name

### DIFF
--- a/pkg/config/hashing_config.go
+++ b/pkg/config/hashing_config.go
@@ -417,6 +417,10 @@ func (c *HashingConfig) hashFiles(modelPath string, filePaths []string) ([]manif
 			return nil, fmt.Errorf("failed to get relative path for %s: %w", filePath, err)
 		}
 
+		if relPath == "." {
+			relPath = filepath.Base(filePath)
+		}
+
 		if !utf8.ValidString(relPath) {
 			return nil, fmt.Errorf("%w: %q", ErrInvalidUTF8Path, relPath)
 		}
@@ -452,6 +456,10 @@ func (c *HashingConfig) hashFilesWithShards(modelPath string, filePaths []string
 		relPath, err := filepath.Rel(modelPath, filePath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get relative path for %s: %w", filePath, err)
+		}
+
+		if relPath == "." {
+			relPath = filepath.Base(filePath)
 		}
 
 		if !utf8.ValidString(relPath) {

--- a/pkg/config/hashing_config_test.go
+++ b/pkg/config/hashing_config_test.go
@@ -945,3 +945,56 @@ func TestHashFiles_ValidUTF8PathAccepted(t *testing.T) {
 		t.Fatalf("expected 1 descriptor, got %d", len(m.ResourceDescriptors()))
 	}
 }
+
+func TestHashFiles_SingleFileUsesBasename(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "model.bin")
+	if err := os.WriteFile(filePath, []byte("weights"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	hc := NewHashingConfig()
+	hc.UseFileSerialization("sha256", false, nil)
+
+	m, err := hc.Hash(filePath, nil)
+	if err != nil {
+		t.Fatalf("Hash single file failed: %v", err)
+	}
+
+	descs := m.ResourceDescriptors()
+	if len(descs) != 1 {
+		t.Fatalf("expected 1 descriptor, got %d", len(descs))
+	}
+	if descs[0].Identifier != "model.bin" {
+		t.Errorf("expected resource name 'model.bin', got %q", descs[0].Identifier)
+	}
+}
+
+func TestHashShards_SingleFileUsesBasename(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "model.bin")
+	if err := os.WriteFile(filePath, []byte("weights-data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	hc := NewHashingConfig()
+	hc.UseShardSerialization("sha256", 4, false, nil)
+
+	m, err := hc.Hash(filePath, nil)
+	if err != nil {
+		t.Fatalf("Hash single file with shards failed: %v", err)
+	}
+
+	descs := m.ResourceDescriptors()
+	if len(descs) == 0 {
+		t.Fatal("expected at least 1 descriptor")
+	}
+	for _, d := range descs {
+		if strings.HasPrefix(d.Identifier, ".") {
+			t.Errorf("resource name should not start with '.', got %q", d.Identifier)
+		}
+		if !strings.HasPrefix(d.Identifier, "model.bin") {
+			t.Errorf("expected resource name starting with 'model.bin', got %q", d.Identifier)
+		}
+	}
+}

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -79,6 +79,11 @@ func (manifest *Manifest) ModelName() string {
 	return manifest.name
 }
 
+// GetSerializationType returns the serialization type used to create this manifest.
+func (manifest *Manifest) GetSerializationType() SerializationType {
+	return manifest.serializationType
+}
+
 // SerializationParameters returns the serialization method and arguments used
 // to build the manifest.
 //

--- a/pkg/verify/helpers.go
+++ b/pkg/verify/helpers.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/sigstore/model-signing/pkg/logging"
+	"github.com/sigstore/model-signing/pkg/manifest"
 	"github.com/sigstore/model-signing/pkg/modelartifact"
 	"github.com/sigstore/sigstore-go/pkg/bundle"
 )
@@ -94,6 +95,10 @@ func CompareModelWithBundle(verifiedPayload []byte, modelPath string, opts model
 	if err != nil {
 		return fmt.Errorf("failed to canonicalize model: %w", err)
 	}
+
+	// Backward compat: legacy bundles (pre-v1.1) stored "." as the resource
+	// name for single-file models. Normalize to basename for comparison.
+	expectedManifest = normalizeLegacyDotResource(expectedManifest, modelPath)
 
 	// Step 4: Compare manifests
 	if ignoreUnsignedFiles {
@@ -264,4 +269,19 @@ func applyBundleCompat(raw map[string]interface{}) {
 		}
 		delete(vm, "x509CertificateChain")
 	}
+}
+
+// normalizeLegacyDotResource handles backward compatibility with pre-v1.1
+// bundles that stored "." as the resource name for single-file models.
+// If the expected manifest has exactly one resource named ".", rebuild it
+// with the model file's basename so comparison succeeds.
+func normalizeLegacyDotResource(expected *manifest.Manifest, modelPath string) *manifest.Manifest {
+	descs := expected.ResourceDescriptors()
+	if len(descs) != 1 || descs[0].Identifier != "." {
+		return expected
+	}
+
+	basename := filepath.Base(modelPath)
+	item := manifest.NewFileManifestItem(basename, descs[0].Digest)
+	return manifest.NewManifest(expected.ModelName(), []manifest.ManifestItem{item}, expected.GetSerializationType())
 }


### PR DESCRIPTION
## Summary

- When signing a single file, `filepath.Rel(path, path)` returns `"."` instead of the filename. Detect this case in both `hashFiles` and `hashFilesWithShards` and use `filepath.Base` to produce the correct basename per spec §6.1.2.

Fixes #131

## Test plan

- [x] `TestHashFiles_SingleFileUsesBasename` — verifies resource name is `model.bin` not `"."`
- [x] `TestHashShards_SingleFileUsesBasename` — verifies shard names start with `model.bin`
- [x] Full `go test ./...` passes

