### PR TITLE
Add DefaultShardSize constant (1 GB)

### DIFF
--- a/pkg/modelartifact/modelartifact.go
+++ b/pkg/modelartifact/modelartifact.go
@@ -184,11 +184,12 @@ func buildHashingConfig(opts Options) *config.HashingConfig {
 
 	hc := config.NewHashingConfig()
 
-	if opts.ShardSize > 0 {
+	switch {
+	case opts.ShardSize > 0:
 		hc.UseShardSerialization(hashAlgorithm, opts.ShardSize, opts.AllowSymlinks, opts.IgnorePaths)
-	} else if opts.ShardSize < 0 {
+	case opts.ShardSize < 0:
 		hc.UseShardSerialization(hashAlgorithm, DefaultShardSize, opts.AllowSymlinks, opts.IgnorePaths)
-	} else {
+	default:
 		hc.UseFileSerialization(hashAlgorithm, opts.AllowSymlinks, opts.IgnorePaths)
 	}
 

--- a/pkg/modelartifact/modelartifact.go
+++ b/pkg/modelartifact/modelartifact.go
@@ -186,6 +186,8 @@ func buildHashingConfig(opts Options) *config.HashingConfig {
 
 	if opts.ShardSize > 0 {
 		hc.UseShardSerialization(hashAlgorithm, opts.ShardSize, opts.AllowSymlinks, opts.IgnorePaths)
+	} else if opts.ShardSize < 0 {
+		hc.UseShardSerialization(hashAlgorithm, DefaultShardSize, opts.AllowSymlinks, opts.IgnorePaths)
 	} else {
 		hc.UseFileSerialization(hashAlgorithm, opts.AllowSymlinks, opts.IgnorePaths)
 	}

--- a/pkg/modelartifact/modelartifact_test.go
+++ b/pkg/modelartifact/modelartifact_test.go
@@ -174,6 +174,28 @@ func TestCanonicalizeWithShards(t *testing.T) {
 	}
 }
 
+func TestCanonicalizeWithDefaultShardSize(t *testing.T) {
+	modelDir := createTestModel(t)
+
+	m, err := Canonicalize(modelDir, Options{
+		ShardSize: -1,
+	})
+	if err != nil {
+		t.Fatalf("Canonicalize with default shard size failed: %v", err)
+	}
+
+	// Test files are small (<1 GB), so each file is one shard
+	descriptors := m.ResourceDescriptors()
+	if len(descriptors) != 3 {
+		t.Errorf("expected 3 descriptors (one shard per small file), got %d", len(descriptors))
+	}
+
+	params := m.SerializationParameters()
+	if params["shard_size"] != DefaultShardSize {
+		t.Errorf("expected shard_size=%d, got %v", DefaultShardSize, params["shard_size"])
+	}
+}
+
 func TestCanonicalizeNonexistentPath(t *testing.T) {
 	_, err := Canonicalize("/nonexistent/path", Options{})
 	if err == nil {

--- a/pkg/modelartifact/options.go
+++ b/pkg/modelartifact/options.go
@@ -38,6 +38,9 @@ import (
 	"github.com/sigstore/model-signing/pkg/logging"
 )
 
+// DefaultShardSize is the recommended shard size per OMS spec §6.3.2 (1 GB).
+const DefaultShardSize int64 = 1_000_000_000
+
 // Options configures how a model is canonicalized.
 type Options struct {
 	// HashAlgorithm is the hash algorithm to use (default: "sha256").
@@ -58,7 +61,8 @@ type Options struct {
 
 	// ShardSize enables shard-based serialization if > 0.
 	// When 0 (default), file-based serialization is used where each file
-	// is hashed as a single unit. When > 0, large files are split into
+	// is hashed as a single unit. When set to -1, DefaultShardSize (1 GB)
+	// is used per OMS spec §6.3.2. When > 0, files are split into
 	// fixed-size shards and each shard is hashed separately.
 	ShardSize int64
 


### PR DESCRIPTION
## Summary

- Adds exported `DefaultShardSize` constant (1,000,000,000 bytes) per OMS spec §6.3.2
- Supports `ShardSize: -1` sentinel to select shard serialization with the spec-recommended default
- Adds test verifying the default shard size behavior

Fixes #129
