### PR TITLE
Reject shard_size when method is "files"

### DIFF
--- a/pkg/manifest/serialization.go
+++ b/pkg/manifest/serialization.go
@@ -134,6 +134,10 @@ func (s *FileSerialization) NewItem(name string, digest digests.Digest) (Manifes
 //
 // Returns an error if required fields are missing or have incorrect types.
 func fileSerializationFromArgs(args map[string]any) (*FileSerialization, error) {
+	if _, ok := args["shard_size"]; ok {
+		return nil, fmt.Errorf("shard_size must not be present when method is %q (spec §5.2.2)", fileMethod)
+	}
+
 	rawHashType, ok := args["hash_type"]
 	if !ok {
 		return nil, fmt.Errorf("file serialization args missing `hash_type`")

--- a/pkg/manifest/serialization_test.go
+++ b/pkg/manifest/serialization_test.go
@@ -183,3 +183,17 @@ func TestSerializationParametersDefensiveCopy(t *testing.T) {
 		}
 	}
 }
+
+func TestFileSerializationRejectsSpuriousShardSize(t *testing.T) {
+	args := map[string]any{
+		"method":         fileMethod,
+		"hash_type":      "sha256",
+		"allow_symlinks": false,
+		"shard_size":     1024,
+	}
+
+	_, err := SerializationTypeFromArgs(args)
+	if err == nil {
+		t.Fatal("expected error for shard_size present with method 'files', got nil")
+	}
+}


### PR DESCRIPTION
## Summary

- Rejects payloads containing `shard_size` when `method` is `"files"`, per OMS spec §5.2.2
- Adds test for the rejection

Fixes #128
