### PR TITLE
Normalize paths with path.Clean per spec §6.1.2

### DIFF
--- a/pkg/manifest/manifest_item.go
+++ b/pkg/manifest/manifest_item.go
@@ -16,6 +16,7 @@ package manifest
 
 import (
 	"fmt"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -49,10 +50,11 @@ type FileManifestItem struct {
 
 // NewFileManifestItem creates a new file manifest item.
 //
-// The path parameter is automatically converted to POSIX form (forward slashes).
-// Returns a FileManifestItem pairing the canonical path with its digest.
-func NewFileManifestItem(path string, digest digests.Digest) *FileManifestItem {
-	key := filepath.ToSlash((path))
+// The path parameter is normalized to POSIX form per OMS spec §6.1.2:
+// forward slashes, collapsed ./ prefixes, interior . components, and
+// redundant separators.
+func NewFileManifestItem(p string, digest digests.Digest) *FileManifestItem {
+	key := path.Clean(filepath.ToSlash(p))
 	return &FileManifestItem{
 		path:   key,
 		digest: digest,
@@ -84,11 +86,10 @@ type ShardedFileManifestItem struct {
 
 // NewShardedFileManifestItem builds a manifest item for a file shard.
 //
-// The path parameter is automatically converted to POSIX form. The start and
-// end parameters define the byte range [start, end) within the file.
-// Returns a ShardedFileManifestItem pairing the shard with its digest.
-func NewShardedFileManifestItem(path string, start, end int64, digest digests.Digest) *ShardedFileManifestItem {
-	canonical := filepath.ToSlash(path)
+// The path parameter is normalized to POSIX form per OMS spec §6.1.2.
+// The start and end parameters define the byte range [start, end) within the file.
+func NewShardedFileManifestItem(p string, start, end int64, digest digests.Digest) *ShardedFileManifestItem {
+	canonical := path.Clean(filepath.ToSlash(p))
 	return &ShardedFileManifestItem{
 		path:   canonical,
 		start:  start,

--- a/pkg/manifest/manifest_item_test.go
+++ b/pkg/manifest/manifest_item_test.go
@@ -168,3 +168,41 @@ func TestShardedFileManifestItemRoundTripName(t *testing.T) {
 		t.Fatalf("Digest mismatch after round-trip")
 	}
 }
+
+func TestFileManifestItemPathNormalization(t *testing.T) {
+	d := digests.NewDigest("sha256", []byte{0x01})
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"./config.json", "config.json"},
+		{"subdir/./weights.bin", "subdir/weights.bin"},
+		{"subdir//file", "subdir/file"},
+		{"./a/./b//c", "a/b/c"},
+		{"normal/path.txt", "normal/path.txt"},
+	}
+	for _, tt := range tests {
+		item := NewFileManifestItem(tt.input, d)
+		if got := item.Name(); got != tt.want {
+			t.Errorf("NewFileManifestItem(%q).Name() = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestShardedFileManifestItemPathNormalization(t *testing.T) {
+	d := digests.NewDigest("sha256", []byte{0x01})
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"./file.bin", "file.bin:0:10"},
+		{"dir/./file.bin", "dir/file.bin:0:10"},
+		{"dir//file.bin", "dir/file.bin:0:10"},
+	}
+	for _, tt := range tests {
+		item := NewShardedFileManifestItem(tt.input, 0, 10, d)
+		if got := item.Name(); got != tt.want {
+			t.Errorf("NewShardedFileManifestItem(%q, 0, 10).Name() = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Applies `path.Clean` after `filepath.ToSlash` in both `NewFileManifestItem` and `NewShardedFileManifestItem` to collapse `./` prefixes, interior `.` components, and redundant separators per OMS spec §6.1.2
- Adds tests covering all normalization cases

Fixes #132
