### PR TITLE
Reject manifest paths with ../ traversal per spec §6.1.2

### DIFF
--- a/pkg/config/hashing_config.go
+++ b/pkg/config/hashing_config.go
@@ -425,6 +425,10 @@ func (c *HashingConfig) hashFiles(modelPath string, filePaths []string) ([]manif
 			return nil, fmt.Errorf("%w: %q", ErrInvalidUTF8Path, relPath)
 		}
 
+		if err := utils.ValidateManifestPath(relPath); err != nil {
+			return nil, err
+		}
+
 		// Create file hasher
 		hasher, err := c.createFileHasher(filePath)
 		if err != nil {
@@ -464,6 +468,10 @@ func (c *HashingConfig) hashFilesWithShards(modelPath string, filePaths []string
 
 		if !utf8.ValidString(relPath) {
 			return nil, fmt.Errorf("%w: %q", ErrInvalidUTF8Path, relPath)
+		}
+
+		if err := utils.ValidateManifestPath(relPath); err != nil {
+			return nil, err
 		}
 
 		fileInfo, err := os.Stat(filePath)

--- a/pkg/config/hashing_config_test.go
+++ b/pkg/config/hashing_config_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/sigstore/model-signing/pkg/logging"
+	"github.com/sigstore/model-signing/pkg/utils"
 )
 
 type capturingLogger struct {
@@ -898,6 +899,54 @@ func TestHashShards_InvalidUTF8PathRejected(t *testing.T) {
 	}
 	if !errors.Is(err, ErrInvalidUTF8Path) {
 		t.Fatalf("expected ErrInvalidUTF8Path, got: %v", err)
+	}
+}
+
+func TestHashFiles_PathTraversalRejected(t *testing.T) {
+	modelDir := t.TempDir()
+	outsideDir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(modelDir, "ok.txt"), []byte("ok"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	escapee := filepath.Join(outsideDir, "secret.txt")
+	if err := os.WriteFile(escapee, []byte("secret"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	hc := NewHashingConfig()
+	hc.UseFileSerialization("sha256", false, nil)
+
+	_, err := hc.Hash(modelDir, []string{escapee})
+	if err == nil {
+		t.Fatal("expected error for path traversal")
+	}
+	if !errors.Is(err, utils.ErrPathTraversal) {
+		t.Fatalf("expected utils.ErrPathTraversal, got: %v", err)
+	}
+}
+
+func TestHashShards_PathTraversalRejected(t *testing.T) {
+	modelDir := t.TempDir()
+	outsideDir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(modelDir, "ok.txt"), []byte("ok"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	escapee := filepath.Join(outsideDir, "secret.txt")
+	if err := os.WriteFile(escapee, []byte("secret"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	hc := NewHashingConfig()
+	hc.UseShardSerialization("sha256", 16, false, nil)
+
+	_, err := hc.Hash(modelDir, []string{escapee})
+	if err == nil {
+		t.Fatal("expected error for path traversal")
+	}
+	if !errors.Is(err, utils.ErrPathTraversal) {
+		t.Fatalf("expected utils.ErrPathTraversal, got: %v", err)
 	}
 }
 

--- a/pkg/utils/validation.go
+++ b/pkg/utils/validation.go
@@ -15,9 +15,11 @@
 package utils
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // PathType represents the type of path to validate.
@@ -135,6 +137,23 @@ func ValidateMultipleRelativeTo(fieldName string, paths []string, baseDir string
 		if err := NewPathValidator(fmt.Sprintf("%s[%d]", fieldName, i), resolved, pathType).Validate(); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// ErrPathTraversal is returned when a manifest path contains parent-directory
+// traversal ("../") or is absolute, violating OMS spec §6.1.2.
+var ErrPathTraversal = errors.New("manifest path must be relative without ../ components")
+
+// ValidateManifestPath checks that a relative path conforms to OMS spec §6.1.2:
+// it must not be absolute and must not contain "../" traversal components.
+func ValidateManifestPath(relPath string) error {
+	if filepath.IsAbs(relPath) {
+		return fmt.Errorf("%w: %s", ErrPathTraversal, relPath)
+	}
+	slashed := filepath.ToSlash(relPath)
+	if slashed == ".." || strings.HasPrefix(slashed, "../") {
+		return fmt.Errorf("%w: %s", ErrPathTraversal, relPath)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- Add `ValidateManifestPath()` to `pkg/utils/validation.go` that rejects absolute paths and `../` traversal components per OMS v1.0 §6.1.2
- Call validation in `hashFiles()` and `hashFilesWithShards()` after `filepath.Rel` computes the relative path, before it enters the manifest
- Add tests confirming paths outside the model root are rejected in both file and shard serialization modes

Closes #133

## Test plan

- [ ] `go test ./pkg/config/... -run PathTraversal -v` — new tests pass
- [ ] `go test ./...` — full suite passes, no regressions
- [ ] `golangci-lint run` — no lint issues