### PR TITLE
Skip non-regular files during hashing per spec §6.1

### DIFF
--- a/pkg/config/hashing_config.go
+++ b/pkg/config/hashing_config.go
@@ -429,6 +429,14 @@ func (c *HashingConfig) hashFiles(modelPath string, filePaths []string) ([]manif
 			return nil, err
 		}
 
+		info, err := os.Stat(filePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to stat %s: %w", filePath, err)
+		}
+		if !info.Mode().IsRegular() {
+			continue
+		}
+
 		// Create file hasher
 		hasher, err := c.createFileHasher(filePath)
 		if err != nil {
@@ -477,6 +485,9 @@ func (c *HashingConfig) hashFilesWithShards(modelPath string, filePaths []string
 		fileInfo, err := os.Stat(filePath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to stat %s: %w", filePath, err)
+		}
+		if !fileInfo.Mode().IsRegular() {
+			continue
 		}
 		fileSize := fileInfo.Size()
 

--- a/pkg/config/hashing_config_test.go
+++ b/pkg/config/hashing_config_test.go
@@ -950,6 +950,97 @@ func TestHashShards_PathTraversalRejected(t *testing.T) {
 	}
 }
 
+func TestHashFiles_NonRegularFileSkipped(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("FIFOs are not supported on Windows")
+	}
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "regular.txt"), []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	fifoPath := filepath.Join(dir, "myfifo")
+	if err := syscall.Mkfifo(fifoPath, 0644); err != nil {
+		t.Fatalf("failed to create FIFO: %v", err)
+	}
+
+	hc := NewHashingConfig()
+	hc.UseFileSerialization("sha256", false, nil)
+
+	m, err := hc.Hash(dir, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, item := range m.ResourceDescriptors() {
+		if item.Identifier == "myfifo" {
+			t.Error("FIFO should not appear in manifest")
+		}
+	}
+}
+
+func TestHashShards_NonRegularFileSkipped(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("FIFOs are not supported on Windows")
+	}
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "regular.txt"), []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	fifoPath := filepath.Join(dir, "myfifo")
+	if err := syscall.Mkfifo(fifoPath, 0644); err != nil {
+		t.Fatalf("failed to create FIFO: %v", err)
+	}
+
+	hc := NewHashingConfig()
+	hc.UseShardSerialization("sha256", 16, false, nil)
+
+	m, err := hc.Hash(dir, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, item := range m.ResourceDescriptors() {
+		if item.Identifier == "myfifo" {
+			t.Error("FIFO should not appear in manifest")
+		}
+	}
+}
+
+func TestHashFiles_NonRegularFileSkippedViaFilesToHash(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("FIFOs are not supported on Windows")
+	}
+
+	dir := t.TempDir()
+	regularPath := filepath.Join(dir, "regular.txt")
+	if err := os.WriteFile(regularPath, []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	fifoPath := filepath.Join(dir, "myfifo")
+	if err := syscall.Mkfifo(fifoPath, 0644); err != nil {
+		t.Fatalf("failed to create FIFO: %v", err)
+	}
+
+	hc := NewHashingConfig()
+	hc.UseFileSerialization("sha256", false, nil)
+
+	m, err := hc.Hash(dir, []string{regularPath, fifoPath})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, item := range m.ResourceDescriptors() {
+		if item.Identifier == "myfifo" {
+			t.Error("FIFO passed via filesToHash should not appear in manifest")
+		}
+	}
+	if len(m.ResourceDescriptors()) != 1 {
+		t.Errorf("expected 1 manifest item, got %d", len(m.ResourceDescriptors()))
+	}
+}
+
 func TestHashShards_EmptyFileOmitted(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "data.bin"), []byte("content"), 0644); err != nil {


### PR DESCRIPTION
## Summary

- Add `IsRegular()` checks in `hashFiles()` and `hashFilesWithShards()` to skip FIFOs, sockets, device nodes, and other non-regular files
- The `walkDirectory` path already filtered correctly via `d.Type().IsRegular()`, but the `filesToHash` path (caller-provided file lists) did not — non-regular files passed through to the hasher, which could hang on FIFOs or produce meaningless hashes for sockets/device nodes
- Add tests using FIFOs to verify non-regular files are silently skipped in both walk and `filesToHash` paths

Closes #134

## Spec reference

OMS v1.0 §6.1: *"The signer MUST recursively enumerate all regular files under the model root directory."*
§5.2.1: *"Implementations MUST NOT include directory entries — only regular files."*

## Test plan

- [ ] `go test ./pkg/config/... -run NonRegular -v` — new tests pass
- [ ] `go test ./...` — full suite passes, no regressions
- [ ] `golangci-lint run` — no lint issues