### PR TITLE
Enforce lexicographic sort order of resources per spec §5.2.1

### DIFF
--- a/pkg/modelartifact/modelartifact_test.go
+++ b/pkg/modelartifact/modelartifact_test.go
@@ -15,9 +15,11 @@
 package modelartifact
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -572,4 +574,86 @@ func searchString(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+func TestUnmarshalPayload_UnsortedResourcesRejected(t *testing.T) {
+	payload := map[string]interface{}{
+		"_type":         "https://in-toto.io/Statement/v1",
+		"predicateType": "https://model_signing/signature/v1.0",
+		"subject": []interface{}{
+			map[string]interface{}{
+				"name":   "test-model",
+				"digest": map[string]interface{}{"sha256": "0000000000000000000000000000000000000000000000000000000000000000"},
+			},
+		},
+		"predicate": map[string]interface{}{
+			"serialization": map[string]interface{}{"method": "files", "hash_type": "sha256", "allow_symlinks": false},
+			"resources": []interface{}{
+				map[string]interface{}{
+					"name":      "b.txt",
+					"algorithm": "sha256",
+					"digest":    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+				},
+				map[string]interface{}{
+					"name":      "a.txt",
+					"algorithm": "sha256",
+					"digest":    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("failed to marshal test payload: %v", err)
+	}
+
+	_, err = UnmarshalPayload(data)
+	if err == nil {
+		t.Fatal("expected error for unsorted resources")
+	}
+	if !strings.Contains(err.Error(), "not sorted") {
+		t.Fatalf("expected sort order error, got: %v", err)
+	}
+}
+
+func TestUnmarshalPayload_DuplicateResourceNamesRejected(t *testing.T) {
+	payload := map[string]interface{}{
+		"_type":         "https://in-toto.io/Statement/v1",
+		"predicateType": "https://model_signing/signature/v1.0",
+		"subject": []interface{}{
+			map[string]interface{}{
+				"name":   "test-model",
+				"digest": map[string]interface{}{"sha256": "0000000000000000000000000000000000000000000000000000000000000000"},
+			},
+		},
+		"predicate": map[string]interface{}{
+			"serialization": map[string]interface{}{"method": "files", "hash_type": "sha256", "allow_symlinks": false},
+			"resources": []interface{}{
+				map[string]interface{}{
+					"name":      "a.txt",
+					"algorithm": "sha256",
+					"digest":    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+				},
+				map[string]interface{}{
+					"name":      "a.txt",
+					"algorithm": "sha256",
+					"digest":    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("failed to marshal test payload: %v", err)
+	}
+
+	_, err = UnmarshalPayload(data)
+	if err == nil {
+		t.Fatal("expected error for duplicate resource names")
+	}
+	if !strings.Contains(err.Error(), "not sorted") {
+		t.Fatalf("expected sort order error, got: %v", err)
+	}
 }

--- a/pkg/modelartifact/payload.go
+++ b/pkg/modelartifact/payload.go
@@ -258,6 +258,14 @@ func unmarshalPayloadV1(dssePayload map[string]interface{}) (*manifest.Manifest,
 		items = append(items, item)
 	}
 
+	// Verify lexicographic sort order of resources (spec §5.2.1)
+	for i := 1; i < len(items); i++ {
+		if items[i].Name() <= items[i-1].Name() {
+			return nil, fmt.Errorf("resources array not sorted lexicographically: %q appears after %q (spec §5.2.1)",
+				items[i].Name(), items[i-1].Name())
+		}
+	}
+
 	// Verify root digest
 	rootDigest, err := memory.ComputeRootDigest(digestList)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Add sort order validation in `unmarshalPayloadV1()` that rejects payloads where the `resources` array is not sorted lexicographically by `name`
- The `<=` comparison also rejects duplicate resource names
- Add tests for both unsorted resources and duplicate names

Closes #135

## Spec reference

OMS v1.0 §5.2.1: *"The `resources` array MUST be sorted lexicographically by `name` using Unicode code point ordering."*

## Test plan

- [ ] `go test ./pkg/modelartifact/... -run "Unsorted|Duplicate" -v` — new tests pass
- [ ] `go test ./...` — full suite passes, no regressions
- [ ] `golangci-lint run` — no lint issues