### PR TITLE
Use allow_symlinks from signed bundle per spec §6.1.1, §8.4

### DIFF
--- a/pkg/verify/helpers.go
+++ b/pkg/verify/helpers.go
@@ -77,10 +77,9 @@ func CompareModelWithBundle(verifiedPayload []byte, modelPath string, opts model
 	if ht, ok := params["hash_type"].(string); ok {
 		canonOpts.HashAlgorithm = ht
 	}
-	// allow_symlinks is the verifier's local policy (CLI flag), not a
-	// structural parameter like hash_type or shard_size. The verifier
-	// decides whether to tolerate symlinks during re-canonicalization.
-	canonOpts.AllowSymlinks = opts.AllowSymlinks
+	if as, ok := params["allow_symlinks"].(bool); ok {
+		canonOpts.AllowSymlinks = as
+	}
 	if ss, ok := params["shard_size"]; ok {
 		switch v := ss.(type) {
 		case int64:

--- a/pkg/verify/helpers_test.go
+++ b/pkg/verify/helpers_test.go
@@ -184,22 +184,15 @@ func TestCompareModelWithBundle_SymlinkAddedAfterSigning(t *testing.T) {
 		t.Skip("symlinks not supported on this platform")
 	}
 
-	// Without AllowSymlinks: should fail (symlink rejected by verifier policy)
-	err := CompareModelWithBundle(payload, modelPath, modelartifact.Options{}, false)
+	// Bundle's allow_symlinks=false is used regardless of caller opts.
+	// Symlink should be rejected even with ignoreUnsigned.
+	err := CompareModelWithBundle(payload, modelPath, modelartifact.Options{}, true)
 	if err == nil {
-		t.Fatal("expected error when symlink present and allow_symlinks=false")
-	}
-
-	// With AllowSymlinks + ignoreUnsigned: verifier policy allows symlinks
-	err = CompareModelWithBundle(payload, modelPath, modelartifact.Options{
-		AllowSymlinks: true,
-	}, true)
-	if err != nil {
-		t.Fatalf("should pass with AllowSymlinks + ignoreUnsigned: %v", err)
+		t.Fatal("expected error: bundle's allow_symlinks=false should reject symlinks")
 	}
 }
 
-func TestCompareModelWithBundle_VerifierPolicyOverridesBundle(t *testing.T) {
+func TestCompareModelWithBundle_BundleAllowSymlinksHonored(t *testing.T) {
 	modelPath := createTestModel(t)
 
 	// Create a symlink before signing
@@ -216,19 +209,11 @@ func TestCompareModelWithBundle_VerifierPolicyOverridesBundle(t *testing.T) {
 		AllowSymlinks: true,
 	})
 
-	// Verify WITHOUT AllowSymlinks: verifier policy rejects symlinks
-	// even though the bundle was signed with allow_symlinks=true
+	// Verify without passing AllowSymlinks in opts — the bundle's
+	// allow_symlinks=true is extracted and used (spec §8.4).
 	err := CompareModelWithBundle(payload, modelPath, modelartifact.Options{}, false)
-	if err == nil {
-		t.Fatal("expected error: verifier policy should reject symlinks regardless of bundle")
-	}
-
-	// Verify WITH AllowSymlinks: should pass
-	err = CompareModelWithBundle(payload, modelPath, modelartifact.Options{
-		AllowSymlinks: true,
-	}, false)
 	if err != nil {
-		t.Fatalf("should pass with AllowSymlinks: %v", err)
+		t.Fatalf("should pass: bundle's allow_symlinks=true should be honored: %v", err)
 	}
 }
 

--- a/scripts/tests/test-hardening.sh
+++ b/scripts/tests/test-hardening.sh
@@ -887,23 +887,13 @@ if ! ${DIR}/model-signing sign key \
 	exit 1
 fi
 
-# Verify signature that includes symlinks requires --allow-symlinks
-# Without the flag, verification fails because symlink triggers an error
-if ${DIR}/model-signing verify key \
-	--signature "${SIGFILE}" \
-	--public-key "${KEYSDIR}/flags-key-pub.pem" \
-	"${MODELDIR}" >/dev/null 2>&1; then
-	echo "  Error: Verify should fail when symlink present and allow_symlinks is false"
-	exit 1
-fi
-
-# Verify with --allow-symlinks should succeed
+# Verify signature that includes symlinks: the verifier uses the bundle's
+# allow_symlinks=true (spec §6.1.1, §8.4), so no CLI flag is needed.
 if ! ${DIR}/model-signing verify key \
 	--signature "${SIGFILE}" \
 	--public-key "${KEYSDIR}/flags-key-pub.pem" \
-	--allow-symlinks \
 	"${MODELDIR}" >/dev/null 2>&1; then
-	echo "  Error: Verify should succeed with --allow-symlinks"
+	echo "  Error: Verify should succeed using bundle's allow_symlinks=true"
 	exit 1
 fi
 

--- a/scripts/tests/test-sign-verify.sh
+++ b/scripts/tests/test-sign-verify.sh
@@ -175,12 +175,12 @@ if ${DIR}/model-signing \
 	exit 1
 fi
 
-# Symlinks cause an error when allow_symlinks is false (OMS spec §6.1.1),
-# so we need --allow-symlinks to let the walker proceed, then
-# --ignore-unsigned-files to accept the extra unsigned files.
+# The bundle was signed with allow_symlinks=false. Per spec §6.1.1 and §8.4,
+# the verifier uses the bundle's allow_symlinks value, so the CLI flag cannot
+# override it. Verification should still fail with symlinks present.
 echo
-echo "Pass signature verification by ignoring any unsigned files or symlinks"
-if ! ${DIR}/model-signing \
+echo "Verify still fails because bundle's allow_symlinks=false overrides CLI flag"
+if ${DIR}/model-signing \
 	verify certificate \
 	--signature "$(basename "${sigfile}")" \
 	--certificate-chain "${DIR}/keys/certificate/ca-cert.pem" \
@@ -188,7 +188,7 @@ if ! ${DIR}/model-signing \
 	--allow-symlinks \
 	--ignore-unsigned-files \
 	. ; then
-	echo "Error: 'verify certificate' failed with --allow-symlinks --ignore-unsigned-files"
+	echo "Error: 'verify certificate' should fail: bundle's allow_symlinks=false rejects symlinks"
 	exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Extract `allow_symlinks` from the signed bundle's serialization parameters instead of using the caller's CLI flag
- This aligns with `hash_type` and `shard_size` which are already extracted from the bundle
- Update tests to reflect the new spec-compliant behavior: the bundle's `allow_symlinks` value is authoritative during verification

Closes #160

## Spec reference

OMS v1.0 §6.1.1: *"The verifier MUST apply the same `allow_symlinks` policy recorded in `serialization.allow_symlinks`."*

OMS v1.0 §8.4 step 5: *"Read `serialization.allow_symlinks` for symlink policy."*

## Behavior change

Previously, the `--allow-symlinks` CLI flag on verify commands overrode the bundle's value. Now the bundle's `allow_symlinks` is used, matching how `hash_type` and `shard_size` already work. The CLI flag is effectively ignored during verification.

## Test plan

- [ ] `go test ./pkg/verify/... -run "Symlink|BundleAllow" -v` — updated tests pass
- [ ] `go test ./...` — full suite passes, no regressions
- [ ] `golangci-lint run` — no lint issues