### PR TITLE
Use ignore_paths from signed bundle per spec §8.4

### DIFF
--- a/pkg/verify/helpers.go
+++ b/pkg/verify/helpers.go
@@ -50,7 +50,7 @@ func LoadBundle(path string) (*bundle.Bundle, error) {
 // DSSE payload, re-canonicalizes the model, and compares the two manifests.
 //
 // Per OMS spec §8.4, the verifier MUST use the serialization parameters
-// (hash_type, method, shard_size, allow_symlinks) from the signed bundle
+// (hash_type, method, shard_size, allow_symlinks, ignore_paths) from the signed bundle
 // when recomputing file digests — not the caller-provided defaults.
 //
 // The verifiedPayload should be the raw in-toto JSON bytes extracted from
@@ -79,6 +79,18 @@ func CompareModelWithBundle(verifiedPayload []byte, modelPath string, opts model
 	}
 	if as, ok := params["allow_symlinks"].(bool); ok {
 		canonOpts.AllowSymlinks = as
+	}
+	if ip, ok := params["ignore_paths"]; ok {
+		switch v := ip.(type) {
+		case []string:
+			canonOpts.IgnorePaths = append(canonOpts.IgnorePaths, v...)
+		case []any:
+			for _, elem := range v {
+				if s, ok := elem.(string); ok {
+					canonOpts.IgnorePaths = append(canonOpts.IgnorePaths, s)
+				}
+			}
+		}
 	}
 	if ss, ok := params["shard_size"]; ok {
 		switch v := ss.(type) {
@@ -131,13 +143,13 @@ func ExtractAndCompareModel(bndl *bundle.Bundle, modelPath, signaturePath string
 	compareOpts := modelartifact.Options{
 		IgnorePaths:    ignorePaths,
 		IgnoreGitPaths: opts.IgnoreGitPaths,
-		AllowSymlinks:  opts.AllowSymlinks,
 		Logger:         logger,
-		// HashAlgorithm and ShardSize are intentionally omitted:
-		// CompareModelWithBundle extracts these from the signed
-		// bundle's serialization parameters (spec §8.4).
-		// AllowSymlinks is passed through so the caller can
-		// override the bundle's value permissively.
+		// HashAlgorithm, ShardSize, AllowSymlinks, and IgnorePaths
+		// are intentionally omitted: CompareModelWithBundle
+		// extracts these from the signed bundle's serialization
+		// parameters (spec §8.4). Caller-provided IgnorePaths
+		// (including the signature file appended above) are
+		// merged with the bundle's ignore_paths.
 	}
 	return CompareModelWithBundle(payloadBytes, modelPath, compareOpts, ignoreUnsignedFiles)
 }

--- a/pkg/verify/helpers_test.go
+++ b/pkg/verify/helpers_test.go
@@ -168,6 +168,54 @@ func TestCompareModelWithBundle_IgnorePathsFromCaller(t *testing.T) {
 	}
 }
 
+func TestCompareModelWithBundle_BundleIgnorePathsHonored(t *testing.T) {
+	modelPath := createTestModel(t)
+
+	// Add a file that will be ignored during signing
+	if err := os.WriteFile(filepath.Join(modelPath, "extra.dat"), []byte("extra"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Sign WITH ignore_paths (bundle records ignore_paths=["extra.dat"])
+	payload := signAndMarshal(t, modelPath, modelartifact.Options{
+		HashAlgorithm: "sha256",
+		IgnorePaths:   []string{"extra.dat"},
+	})
+
+	// Verify without passing IgnorePaths in opts — the bundle's
+	// ignore_paths=["extra.dat"] is extracted and used (spec §8.4).
+	err := CompareModelWithBundle(payload, modelPath, modelartifact.Options{}, false)
+	if err != nil {
+		t.Fatalf("should pass: bundle's ignore_paths should be honored: %v", err)
+	}
+}
+
+func TestCompareModelWithBundle_IgnorePathsMerged(t *testing.T) {
+	modelPath := createTestModel(t)
+
+	// Sign with bundle ignoring one file
+	payload := signAndMarshal(t, modelPath, modelartifact.Options{
+		HashAlgorithm: "sha256",
+		IgnorePaths:   []string{"bundle-ignored.dat"},
+	})
+
+	// Add two extra files after signing
+	if err := os.WriteFile(filepath.Join(modelPath, "bundle-ignored.dat"), []byte("b"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(modelPath, "caller-ignored.dat"), []byte("c"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify with caller ignoring the other file — both should be excluded
+	err := CompareModelWithBundle(payload, modelPath, modelartifact.Options{
+		IgnorePaths: []string{"caller-ignored.dat"},
+	}, false)
+	if err != nil {
+		t.Fatalf("should pass with merged ignore paths: %v", err)
+	}
+}
+
 func TestCompareModelWithBundle_SymlinkAddedAfterSigning(t *testing.T) {
 	modelPath := createTestModel(t)
 

--- a/scripts/tests/test-hardening.sh
+++ b/scripts/tests/test-hardening.sh
@@ -818,6 +818,34 @@ echo "  --ignore-paths: PASSED"
 
 rm "${MODELDIR}/should-ignore.txt"
 
+# --- Test ignore_paths from signed bundle (spec §8.4, issue #161) ---
+echo "[Flags] Testing ignore_paths honored from signed bundle..."
+SIGFILE="${TMPDIR}/ignore-paths-bundle.sig"
+
+# Add a file and sign WITH --ignore-paths so it's recorded in the bundle
+echo "bundle-ignored" > "${MODELDIR}/bundle-ignored.txt"
+if ! ${DIR}/model-signing sign key \
+	--signature "${SIGFILE}" \
+	--private-key "${KEYSDIR}/flags-key.pem" \
+	--ignore-paths "bundle-ignored.txt" \
+	"${MODELDIR}" >/dev/null 2>&1; then
+	echo "  Error: Sign with --ignore-paths failed"
+	exit 1
+fi
+
+# Verify WITHOUT --ignore-paths should succeed because the bundle
+# records ignore_paths=["bundle-ignored.txt"] (spec §8.4)
+if ! ${DIR}/model-signing verify key \
+	--signature "${SIGFILE}" \
+	--public-key "${KEYSDIR}/flags-key-pub.pem" \
+	"${MODELDIR}" >/dev/null 2>&1; then
+	echo "  Error: Verification should pass using bundle's ignore_paths"
+	exit 1
+fi
+echo "  ignore_paths from bundle: PASSED"
+
+rm "${MODELDIR}/bundle-ignored.txt"
+
 # --- Test --ignore-unsigned-files ---
 echo "[Flags] Testing --ignore-unsigned-files..."
 SIGFILE="${TMPDIR}/ignore-unsigned.sig"


### PR DESCRIPTION
## Summary

- Extract `ignore_paths` from the signed bundle's serialization parameters during verification, per OMS spec §8.4 step 4
- Merge bundle-sourced paths with caller-provided paths (e.g. the signature file appended by `ExtractAndCompareModel`)
- Add unit tests for bundle-only and merged ignore paths, plus integration test in `test-hardening.sh`

Fixes #161

## Spec References

- **§8.4 step 4:** "Read `serialization.ignore_paths` if present."
- **§8.4 step 6:** "Enumerate all model files applying same exclusion rules and symlink policy."

## Test plan

- [x] `go test ./pkg/verify/...` — new unit tests pass (`BundleIgnorePathsHonored`, `IgnorePathsMerged`)
- [x] `go test ./...` — full test suite passes
- [x] `go vet ./...` — no issues
- [x] `test-hardening.sh` — new integration test passes (sign with `--ignore-paths`, verify without)
- [x] `test-sign-verify.sh` — existing tests still pass (harmless duplicate ignore paths from merge)