### PR TITLE
Validate shard_size as positive integer per spec §6.3.2

### DIFF
--- a/pkg/manifest/serialization.go
+++ b/pkg/manifest/serialization.go
@@ -276,6 +276,10 @@ func shardSerializationFromArgs(args map[string]any) (*ShardSerialization, error
 		return nil, fmt.Errorf("shard serialization `shard_size` must be numeric, got %T", rawShardSize)
 	}
 
+	if shardSize <= 0 {
+		return nil, fmt.Errorf("shard serialization `shard_size` must be a positive integer (spec §6.3.2), got %d", shardSize)
+	}
+
 	rawAllowSymlinks, ok := args["allow_symlinks"]
 	if !ok {
 		return nil, fmt.Errorf("shard serialization args missing `allow_symlinks`")

--- a/pkg/manifest/serialization_test.go
+++ b/pkg/manifest/serialization_test.go
@@ -184,6 +184,34 @@ func TestSerializationParametersDefensiveCopy(t *testing.T) {
 	}
 }
 
+func TestShardSerializationFromArgsRejectsZeroShardSize(t *testing.T) {
+	args := map[string]any{
+		"method":         shardMethod,
+		"hash_type":      "sha256",
+		"shard_size":     0,
+		"allow_symlinks": false,
+	}
+
+	_, err := SerializationTypeFromArgs(args)
+	if err == nil {
+		t.Fatal("expected error for shard_size=0, got nil")
+	}
+}
+
+func TestShardSerializationFromArgsRejectsNegativeShardSize(t *testing.T) {
+	args := map[string]any{
+		"method":         shardMethod,
+		"hash_type":      "sha256",
+		"shard_size":     int64(-1),
+		"allow_symlinks": false,
+	}
+
+	_, err := SerializationTypeFromArgs(args)
+	if err == nil {
+		t.Fatal("expected error for negative shard_size, got nil")
+	}
+}
+
 func TestFileSerializationRejectsSpuriousShardSize(t *testing.T) {
 	args := map[string]any{
 		"method":         fileMethod,


### PR DESCRIPTION
## Summary

- Reject `shard_size <= 0` in `shardSerializationFromArgs` with a clear error referencing spec §6.3.2
- Prevents division-by-zero panic in `hashFilesWithShards` when verifying a malicious bundle with `shard_size: 0`
- Prevents incorrect shard boundaries from negative values

Fixes #162

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test ./pkg/manifest/...` — new tests pass (`RejectsZeroShardSize`, `RejectsNegativeShardSize`)
- [x] `go test ./...` — full suite passes