### PR TITLE
Ensure symlink warnings are never silently dropped per spec §6.1.1

### DIFF
--- a/pkg/modelartifact/modelartifact.go
+++ b/pkg/modelartifact/modelartifact.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/sigstore/model-signing/pkg/config"
+	"github.com/sigstore/model-signing/pkg/logging"
 	"github.com/sigstore/model-signing/pkg/manifest"
 	"github.com/sigstore/model-signing/pkg/oci"
 	"github.com/sigstore/model-signing/pkg/utils"
@@ -198,9 +199,7 @@ func buildHashingConfig(opts Options) *config.HashingConfig {
 	// kept for backward compatibility but no longer controls this.
 	hc.SetIgnoredPaths(opts.IgnorePaths, true)
 
-	if opts.Logger != nil {
-		hc.SetLogger(opts.Logger)
-	}
+	hc.SetLogger(logging.EnsureLogger(opts.Logger))
 
 	return hc
 }


### PR DESCRIPTION
## Summary

- Use `logging.EnsureLogger()` in `buildHashingConfig` to guarantee a fallback logger, matching the pattern all signers and verifiers already follow
- Prevents spec-mandated symlink warnings (outside-root target, cycle detection) from being silently discarded when no explicit logger is configured

Fixes #163

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test ./...` — all tests pass
- Existing tests in `pkg/config/hashing_config_test.go` (`TestWalkDirectory_SymlinkOutsideRootWarns`, `TestWalkDirectory_SymlinkCycleWarns`) already validate warning content with an explicit logger