### PR TITLE
Remove .gitmodules from default exclusions per spec §6.2

### DIFF
--- a/pkg/config/hashing_config.go
+++ b/pkg/config/hashing_config.go
@@ -71,13 +71,12 @@ type HashingConfig struct {
 // PathLike is a type alias for path-like strings.
 type PathLike = string
 
-// gitRelatedPaths defines common git-related paths to ignore during hashing.
+// gitRelatedPaths defines git-related paths excluded by default per spec §6.2.
 var gitRelatedPaths = []string{
 	".git",
 	".gitignore",
 	".gitattributes",
 	".github",
-	".gitmodules",
 }
 
 // NewHashingConfig creates a new hashing configuration with defaults.

--- a/pkg/modelartifact/modelartifact.go
+++ b/pkg/modelartifact/modelartifact.go
@@ -193,9 +193,9 @@ func buildHashingConfig(opts Options) *config.HashingConfig {
 		hc.UseFileSerialization(hashAlgorithm, opts.AllowSymlinks, opts.IgnorePaths)
 	}
 
-	// Git paths (.git, .gitignore, .gitattributes, .github, .gitmodules)
-	// are always excluded per spec §6.2. The IgnoreGitPaths field is
-	// kept for backward compatibility but no longer controls this.
+	// Git paths (.git, .gitignore, .gitattributes, .github) are always
+	// excluded per spec §6.2. The IgnoreGitPaths field is kept for
+	// backward compatibility but no longer controls this.
 	hc.SetIgnoredPaths(opts.IgnorePaths, true)
 
 	if opts.Logger != nil {

--- a/pkg/modelartifact/options.go
+++ b/pkg/modelartifact/options.go
@@ -52,8 +52,8 @@ type Options struct {
 	IgnorePaths []string
 
 	// IgnoreGitPaths is retained for backward compatibility but has no effect.
-	// Git paths (.git, .gitignore, .gitattributes, .github, .gitmodules) are
-	// always excluded per OMS spec §6.2.
+	// Git paths (.git, .gitignore, .gitattributes, .github) are always
+	// excluded per OMS spec §6.2.
 	IgnoreGitPaths bool
 
 	// AllowSymlinks follows symbolic links instead of skipping them.


### PR DESCRIPTION
## Summary

- Remove `.gitmodules` from `gitRelatedPaths` — the spec lists exactly four mandatory exclusions (`.git`, `.gitignore`, `.gitattributes`, `.github`)
- The extra entry breaks cross-implementation interoperability: the Python implementation includes `.gitmodules` in resources, producing different manifests and root digests for the same model

Fixes #164

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test ./...` — all tests pass (no tests referenced `.gitmodules`)