### PR TITLE
Validate serialization method from bundle per spec §8.4

### DIFF
--- a/pkg/verify/helpers.go
+++ b/pkg/verify/helpers.go
@@ -102,6 +102,12 @@ func CompareModelWithBundle(verifiedPayload []byte, modelPath string, opts model
 			canonOpts.ShardSize = int64(v)
 		}
 	}
+	// Validate method per spec §8.4 step 1.
+	if method, ok := params["method"].(string); ok {
+		if method == "shards" && canonOpts.ShardSize == 0 {
+			return fmt.Errorf("bundle specifies shard serialization but shard_size is missing or zero")
+		}
+	}
 
 	// Step 3: Re-canonicalize the model to get the actual manifest
 	actualManifest, err := modelartifact.Canonicalize(modelPath, canonOpts)

--- a/pkg/verify/helpers_test.go
+++ b/pkg/verify/helpers_test.go
@@ -22,6 +22,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
+	"encoding/json"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -116,6 +117,35 @@ func TestCompareModelWithBundle_Blake2bShardRoundTrip(t *testing.T) {
 	err := CompareModelWithBundle(payload, modelPath, modelartifact.Options{}, false)
 	if err != nil {
 		t.Fatalf("blake2b+shard round-trip failed: %v", err)
+	}
+}
+
+func TestCompareModelWithBundle_ShardMethodMissingSizeRejects(t *testing.T) {
+	modelPath := createTestModel(t)
+
+	// Sign with shards to get a valid shard payload
+	payload := signAndMarshal(t, modelPath, modelartifact.Options{
+		HashAlgorithm: "sha256",
+		ShardSize:     16,
+	})
+
+	// Tamper: remove shard_size from serialization params so method
+	// says "shards" but shard_size is absent (spec §8.4 step 1).
+	var raw map[string]interface{}
+	if err := json.Unmarshal(payload, &raw); err != nil {
+		t.Fatal(err)
+	}
+	predicate := raw["predicate"].(map[string]interface{})
+	serialization := predicate["serialization"].(map[string]interface{})
+	delete(serialization, "shard_size")
+	tampered, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = CompareModelWithBundle(tampered, modelPath, modelartifact.Options{}, false)
+	if err == nil {
+		t.Fatal("expected error for shard method without shard_size")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Explicitly read and validate `method` from the bundle's serialization parameters per spec §8.4 step 1
- Reject bundles where `method` is `"shards"` but `shard_size` is missing or zero, instead of silently falling back to file serialization
- Defense in depth alongside `UnmarshalPayload` validation

Fixes #165

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test ./...` — all tests pass
- [x] New test `TestCompareModelWithBundle_ShardMethodMissingSizeRejects` — tampered payload with method "shards" and removed shard_size is rejected