### PR TITLE
Remove redundant ignore paths from Use*Serialization calls

### DIFF
--- a/pkg/modelartifact/modelartifact.go
+++ b/pkg/modelartifact/modelartifact.go
@@ -185,18 +185,17 @@ func buildHashingConfig(opts Options) *config.HashingConfig {
 
 	hc := config.NewHashingConfig()
 
+	// Ignore paths (user-provided + git defaults per spec §6.2) are set
+	// once via SetIgnoredPaths; nil is passed to Use*Serialization so
+	// paths are not appended twice.
 	switch {
 	case opts.ShardSize > 0:
-		hc.UseShardSerialization(hashAlgorithm, opts.ShardSize, opts.AllowSymlinks, opts.IgnorePaths)
+		hc.UseShardSerialization(hashAlgorithm, opts.ShardSize, opts.AllowSymlinks, nil)
 	case opts.ShardSize < 0:
-		hc.UseShardSerialization(hashAlgorithm, DefaultShardSize, opts.AllowSymlinks, opts.IgnorePaths)
+		hc.UseShardSerialization(hashAlgorithm, DefaultShardSize, opts.AllowSymlinks, nil)
 	default:
-		hc.UseFileSerialization(hashAlgorithm, opts.AllowSymlinks, opts.IgnorePaths)
+		hc.UseFileSerialization(hashAlgorithm, opts.AllowSymlinks, nil)
 	}
-
-	// Git paths (.git, .gitignore, .gitattributes, .github) are always
-	// excluded per spec §6.2. The IgnoreGitPaths field is kept for
-	// backward compatibility but no longer controls this.
 	hc.SetIgnoredPaths(opts.IgnorePaths, true)
 
 	hc.SetLogger(logging.EnsureLogger(opts.Logger))


### PR DESCRIPTION
## Summary

- Pass `nil` instead of `opts.IgnorePaths` to `Use*Serialization` in `buildHashingConfig`
- `SetIgnoredPaths` immediately overwrites `hc.ignoredPaths` with the same paths plus git defaults, so the earlier append was wasted
- Ignore paths are now set in exactly one place

Fixes #166

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test ./...` — all tests pass