### PR TITLE
Store relative POSIX paths in AddIgnoredPaths per spec §6.2.1

### DIFF
--- a/pkg/config/hashing_config.go
+++ b/pkg/config/hashing_config.go
@@ -164,23 +164,29 @@ func (c *HashingConfig) SetIgnoredPaths(paths []string, ignoreGitPaths bool) *Ha
 
 // AddIgnoredPaths adds additional paths to the ignore list.
 //
-// The paths are interpreted relative to modelPath.
+// Absolute paths are converted to relative paths using modelPath as
+// the base. All paths are stored as forward-slash POSIX paths per
+// spec §6.2.1 so they are portable across machines and OSes.
 //
 // Parameters:
-//   - modelPath: Base path for resolving relative paths
+//   - modelPath: Base path for resolving absolute paths to relative
 //   - paths: Paths to add to the ignore list (can be absolute or relative)
 //
 // Returns the HashingConfig for method chaining.
 func (c *HashingConfig) AddIgnoredPaths(modelPath string, paths []string) *HashingConfig {
 	for _, p := range paths {
-		// Make path absolute relative to model path if not already absolute
-		var absPath string
+		var relPath string
 		if filepath.IsAbs(p) {
-			absPath = p
+			rel, err := filepath.Rel(modelPath, p)
+			if err != nil {
+				relPath = filepath.ToSlash(p)
+			} else {
+				relPath = filepath.ToSlash(rel)
+			}
 		} else {
-			absPath = filepath.Join(modelPath, p)
+			relPath = filepath.ToSlash(p)
 		}
-		c.ignoredPaths = append(c.ignoredPaths, absPath)
+		c.ignoredPaths = append(c.ignoredPaths, relPath)
 	}
 	return c
 }

--- a/pkg/config/hashing_config_test.go
+++ b/pkg/config/hashing_config_test.go
@@ -237,7 +237,7 @@ func TestSetIgnoredPaths_StoresInManifest(t *testing.T) {
 func TestAddIgnoredPaths(t *testing.T) {
 	config := NewHashingConfig()
 	modelPath := "/test/model"
-	newPaths := []string{"relative/path", "/absolute/path"}
+	newPaths := []string{"relative/path", "/test/model/subdir/file"}
 
 	config.AddIgnoredPaths(modelPath, newPaths)
 
@@ -245,29 +245,28 @@ func TestAddIgnoredPaths(t *testing.T) {
 		t.Errorf("Expected 2 ignoredPaths, got %d", len(config.ignoredPaths))
 	}
 
-	// Relative path should be converted to absolute
-	expectedRelative := filepath.Join(modelPath, "relative/path")
+	// Relative path should stay relative with forward slashes
 	found := false
 	for _, p := range config.ignoredPaths {
-		if p == expectedRelative {
+		if p == "relative/path" {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Errorf("Expected relative path to be converted to '%s'", expectedRelative)
+		t.Errorf("Expected relative path 'relative/path', got %v", config.ignoredPaths)
 	}
 
-	// Absolute path should remain absolute
+	// Absolute path should be converted to relative POSIX path
 	found = false
 	for _, p := range config.ignoredPaths {
-		if p == "/absolute/path" {
+		if p == "subdir/file" {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Error("Expected absolute path to remain unchanged")
+		t.Errorf("Expected absolute path converted to 'subdir/file', got %v", config.ignoredPaths)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `AddIgnoredPaths` now stores relative POSIX paths instead of absolute OS paths
- Absolute input paths are converted to relative using `modelPath` as the base; relative inputs are preserved as-is with forward slashes
- Prevents non-portable absolute OS paths from leaking into `serialization.ignore_paths` in signed bundles
- Spec §6.2.1 requires forward-slash separators and no leading `/`

Fixes #167

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test ./...` — all tests pass
- [x] Updated `TestAddIgnoredPaths` to verify relative POSIX output for both relative and absolute inputs