### PR TITLE
Honor IgnoreGitPaths option instead of hardcoding true

### DIFF
--- a/pkg/modelartifact/modelartifact.go
+++ b/pkg/modelartifact/modelartifact.go
@@ -185,9 +185,8 @@ func buildHashingConfig(opts Options) *config.HashingConfig {
 
 	hc := config.NewHashingConfig()
 
-	// Ignore paths (user-provided + git defaults per spec §6.2) are set
-	// once via SetIgnoredPaths; nil is passed to Use*Serialization so
-	// paths are not appended twice.
+	// Ignore paths are set once via SetIgnoredPaths; nil is passed to
+	// Use*Serialization so paths are not appended twice.
 	switch {
 	case opts.ShardSize > 0:
 		hc.UseShardSerialization(hashAlgorithm, opts.ShardSize, opts.AllowSymlinks, nil)
@@ -196,7 +195,7 @@ func buildHashingConfig(opts Options) *config.HashingConfig {
 	default:
 		hc.UseFileSerialization(hashAlgorithm, opts.AllowSymlinks, nil)
 	}
-	hc.SetIgnoredPaths(opts.IgnorePaths, true)
+	hc.SetIgnoredPaths(opts.IgnorePaths, opts.IgnoreGitPaths)
 
 	hc.SetLogger(logging.EnsureLogger(opts.Logger))
 

--- a/pkg/modelartifact/modelartifact_test.go
+++ b/pkg/modelartifact/modelartifact_test.go
@@ -548,8 +548,8 @@ func TestCanonicalizeDefaultExcludesGitPaths(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Use default Options{} — git paths must still be excluded (spec §6.2)
-	m, err := Canonicalize(dir, Options{})
+	// IgnoreGitPaths: true excludes git paths per spec §6.2
+	m, err := Canonicalize(dir, Options{IgnoreGitPaths: true})
 	if err != nil {
 		t.Fatalf("Canonicalize failed: %v", err)
 	}

--- a/pkg/modelartifact/options.go
+++ b/pkg/modelartifact/options.go
@@ -51,9 +51,9 @@ type Options struct {
 	// Paths can be absolute or relative to the model root.
 	IgnorePaths []string
 
-	// IgnoreGitPaths is retained for backward compatibility but has no effect.
-	// Git paths (.git, .gitignore, .gitattributes, .github) are always
-	// excluded per OMS spec §6.2.
+	// IgnoreGitPaths controls whether git-related paths (.git, .gitignore,
+	// .gitattributes, .github) are automatically excluded per spec §6.2.
+	// Defaults to false (zero value); the CLI sets this to true by default.
 	IgnoreGitPaths bool
 
 	// AllowSymlinks follows symbolic links instead of skipping them.


### PR DESCRIPTION
## Summary

- `buildHashingConfig` now passes `opts.IgnoreGitPaths` to `SetIgnoredPaths` instead of hardcoded `true`
- Users can opt out of git path exclusion via `--ignore-git-paths=false` on the CLI
- The CLI defaults to `true`, preserving the spec §6.2 default behavior

Fixes #168

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test ./...` — all tests pass
- [x] Updated `TestCanonicalizeDefaultExcludesGitPaths` to explicitly set `IgnoreGitPaths: true`