### PR TITLE
Assert resource sort order during marshal per spec §5.2.1

### DIFF
--- a/pkg/modelartifact/payload.go
+++ b/pkg/modelartifact/payload.go
@@ -53,6 +53,14 @@ func MarshalPayload(m *manifest.Manifest) ([]byte, error) {
 		resources = append(resources, resource)
 	}
 
+	// Assert lexicographic sort order of resources (spec §5.2.1).
+	for i := 1; i < len(resources); i++ {
+		if resources[i]["name"].(string) <= resources[i-1]["name"].(string) {
+			return nil, fmt.Errorf("resources not sorted lexicographically: %q appears after %q (spec §5.2.1)",
+				resources[i]["name"], resources[i-1]["name"])
+		}
+	}
+
 	// Compute root digest (SHA256 over all individual digests in order)
 	rootDigest, err := memory.ComputeRootDigest(digestList)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Add defensive sort-order assertion in `MarshalPayload` after building the resources list
- Spec §5.2.1: "The `resources` array MUST be sorted lexicographically by the `name` field using Unicode code point ordering"
- Unmarshal already validates this; marshal now catches violations before producing non-compliant bundles

Fixes #169

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test ./...` — all tests pass