### PR TITLE
Derive git-path exclusion from bundle during verification

### DIFF
--- a/pkg/manifest/serialization.go
+++ b/pkg/manifest/serialization.go
@@ -109,17 +109,15 @@ func (s *FileSerialization) Method() string {
 // The returned map contains method, hash_type, allow_symlinks, and optionally
 // ignore_paths. Returns a new map with a copy of the ignorePaths slice.
 func (s *FileSerialization) Parameters() map[string]any {
-	params := map[string]any{
+	pathsCopy := make([]string, len(s.ignorePaths))
+	copy(pathsCopy, s.ignorePaths)
+
+	return map[string]any{
 		"method":         s.Method(),
 		"hash_type":      s.hashType,
 		"allow_symlinks": s.allowSymlinks,
+		"ignore_paths":   pathsCopy,
 	}
-	if len(s.ignorePaths) > 0 {
-		pathsCopy := make([]string, len(s.ignorePaths))
-		copy(pathsCopy, s.ignorePaths)
-		params["ignore_paths"] = pathsCopy
-	}
-	return params
 }
 
 // NewItem creates a ManifestItem from a name and digest.
@@ -219,18 +217,16 @@ func (s *ShardSerialization) Method() string {
 // The returned map contains method, hash_type, shard_size, allow_symlinks,
 // and optionally ignore_paths. Returns a new map with a copy of the ignorePaths slice.
 func (s *ShardSerialization) Parameters() map[string]any {
-	params := map[string]any{
+	pathsCopy := make([]string, len(s.ignorePaths))
+	copy(pathsCopy, s.ignorePaths)
+
+	return map[string]any{
 		"method":         s.Method(),
 		"hash_type":      s.hashType,
 		"shard_size":     s.shardSize,
 		"allow_symlinks": s.allowSymlinks,
+		"ignore_paths":   pathsCopy,
 	}
-	if len(s.ignorePaths) > 0 {
-		pathsCopy := make([]string, len(s.ignorePaths))
-		copy(pathsCopy, s.ignorePaths)
-		params["ignore_paths"] = pathsCopy
-	}
-	return params
 }
 
 // NewItem creates a ManifestItem from a name and digest.

--- a/pkg/verify/helpers.go
+++ b/pkg/verify/helpers.go
@@ -83,6 +83,10 @@ func CompareModelWithBundle(verifiedPayload []byte, modelPath string, opts model
 		canonOpts.AllowSymlinks = as
 	}
 	if ip, ok := params["ignore_paths"]; ok {
+		// Bundle records explicit ignore paths — use them and disable
+		// independent git-path addition to avoid deviating from the
+		// signer's exclusion rules (spec §8.4 step 6).
+		canonOpts.IgnoreGitPaths = false
 		switch v := ip.(type) {
 		case []string:
 			canonOpts.IgnorePaths = append(canonOpts.IgnorePaths, v...)

--- a/pkg/verify/helpers_test.go
+++ b/pkg/verify/helpers_test.go
@@ -246,6 +246,31 @@ func TestCompareModelWithBundle_IgnorePathsMerged(t *testing.T) {
 	}
 }
 
+func TestCompareModelWithBundle_BundleIgnoreGitPathsDerived(t *testing.T) {
+	modelPath := createTestModel(t)
+
+	// Add a git-related file
+	if err := os.WriteFile(filepath.Join(modelPath, ".gitignore"), []byte("*.log"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Sign WITHOUT ignoring git paths — .gitignore is included in manifest
+	payload := signAndMarshal(t, modelPath, modelartifact.Options{
+		HashAlgorithm:  "sha256",
+		IgnoreGitPaths: false,
+	})
+
+	// Verify with IgnoreGitPaths: true (CLI default) — should still pass
+	// because the bundle's ignore_paths does not contain git paths, so
+	// CompareModelWithBundle sets IgnoreGitPaths=false (spec §8.4 step 6).
+	err := CompareModelWithBundle(payload, modelPath, modelartifact.Options{
+		IgnoreGitPaths: true,
+	}, false)
+	if err != nil {
+		t.Fatalf("should pass: verifier should derive git-path exclusion from bundle: %v", err)
+	}
+}
+
 func TestCompareModelWithBundle_SymlinkAddedAfterSigning(t *testing.T) {
 	modelPath := createTestModel(t)
 


### PR DESCRIPTION
## Summary

- When the bundle has `ignore_paths`, set `IgnoreGitPaths=false` so git paths aren't independently added — the bundle's list already captures them if they were excluded during signing
- When `ignore_paths` is absent (old bundles), keep the CLI default `--ignore-git-paths=true` for backward compatibility
- Always emit `ignore_paths` in serialization `Parameters()` (even when empty) so new bundles can be distinguished from pre-v1.1 bundles that never recorded this field

### Why

Per spec §8.4 step 6: "applying the **same** exclusion rules." The verifier's CLI default `--ignore-git-paths=true` could differ from the signer's intent — if the signer used `--ignore-git-paths=false`, git files would be in the manifest but the verifier would exclude them, causing false "missing files" failures.

### Cross-verified against prior fixes

- Issue #161 (ignore_paths from bundle): `params["ignore_paths"]` now always exists for new bundles. Merge appends empty slice (no-op) — safe.
- Issue #168 (IgnoreGitPaths honored): `IgnoreGitPaths` is overridden to `false` when bundle has `ignore_paths`, preventing double-add.
- Old bundles: `ignore_paths` key absent (wasn't emitted when empty before), CLI default preserved — backward compatible.

Fixes #185

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test ./...` — all tests pass
- [x] New test `TestCompareModelWithBundle_BundleIgnoreGitPathsDerived` — sign without git exclusion, verify with default `IgnoreGitPaths=true`, passes because bundle's intent is honored
- [x] `test-hardening.sh` — all integration tests pass
- [x] `test-sign-verify.sh` — all integration tests pass
- [x] Backward-compat: `test-verify-v0.3.1-elliptic-key.sh`, `test-verify-v1.0.0-elliptic-key.sh`, `test-verify-v1.0.1-elliptic-key.sh` — all pass