### PR TITLE
Add fuzz tests for untrusted input parsing boundaries

### DIFF
--- a/.github/workflows/fuzz-tests.yml
+++ b/.github/workflows/fuzz-tests.yml
@@ -1,0 +1,56 @@
+# Copyright 2025 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Fuzz Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: '17 3 * * 2,5'  # Tue/Fri 3:17 AM UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    name: Fuzz tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - { pkg: ./pkg/verify/, func: FuzzLoadBundleWithCompat }
+          - { pkg: ./pkg/verify/, func: FuzzExtractCertChainFromJSON }
+          - { pkg: ./pkg/modelartifact/, func: FuzzUnmarshalPayload }
+          - { pkg: ./pkg/modelartifact/, func: FuzzValidateIgnorePaths }
+          - { pkg: ./pkg/manifest/, func: FuzzSerializationTypeFromArgs }
+          - { pkg: ./pkg/manifest/, func: FuzzParseShardName }
+          - { pkg: ./pkg/oci/, func: FuzzParseManifest }
+          - { pkg: ./pkg/oci/, func: FuzzValidateDigestFormat }
+          - { pkg: ./pkg/oci/, func: FuzzParseDigestString }
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: './go.mod'
+          check-latest: true
+
+      - name: Fuzz ${{ matrix.target.func }}
+        run: go test -fuzz=${{ matrix.target.func }} -fuzztime=30s ${{ matrix.target.pkg }}

--- a/pkg/manifest/manifest_item_test.go
+++ b/pkg/manifest/manifest_item_test.go
@@ -206,3 +206,17 @@ func TestShardedFileManifestItemPathNormalization(t *testing.T) {
 		}
 	}
 }
+
+func FuzzParseShardName(f *testing.F) {
+	f.Add("file.bin:0:1024")
+	f.Add("dir/file.bin:100:200")
+	f.Add("path:with:colons:0:10")
+	f.Add(":0:10")
+	f.Add("file:0:")
+	f.Add("")
+	f.Add("no-colons")
+
+	f.Fuzz(func(t *testing.T, name string) {
+		_, _, _, _ = parseShardName(name)
+	})
+}

--- a/pkg/manifest/serialization_test.go
+++ b/pkg/manifest/serialization_test.go
@@ -15,6 +15,7 @@
 package manifest
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 
@@ -210,6 +211,22 @@ func TestShardSerializationFromArgsRejectsNegativeShardSize(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for negative shard_size, got nil")
 	}
+}
+
+func FuzzSerializationTypeFromArgs(f *testing.F) {
+	f.Add([]byte(`{"method":"files","hash_type":"sha256","allow_symlinks":false,"ignore_paths":[]}`))
+	f.Add([]byte(`{"method":"shards","hash_type":"sha256","shard_size":1024,"allow_symlinks":false}`))
+	f.Add([]byte(`{"method":"unknown"}`))
+	f.Add([]byte(`{}`))
+	f.Add([]byte(``))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var args map[string]any
+		if json.Unmarshal(data, &args) != nil {
+			return
+		}
+		_, _ = SerializationTypeFromArgs(args)
+	})
 }
 
 func TestFileSerializationRejectsSpuriousShardSize(t *testing.T) {

--- a/pkg/modelartifact/modelartifact_test.go
+++ b/pkg/modelartifact/modelartifact_test.go
@@ -617,6 +617,30 @@ func TestUnmarshalPayload_UnsortedResourcesRejected(t *testing.T) {
 	}
 }
 
+func FuzzUnmarshalPayload(f *testing.F) {
+	f.Add([]byte(`{"_type":"https://in-toto.io/Statement/v1","predicateType":"https://model_signing/signature/v1.0","subject":[{"name":"test","digest":{"sha256":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}}],"predicate":{"serialization":{"method":"files","hash_type":"sha256","allow_symlinks":false,"ignore_paths":[]},"resources":[]}}`))
+	f.Add([]byte(`{"_type":"https://in-toto.io/Statement/v0.1","predicateType":"https://model_signing/Digests/v0.1","subject":[]}`))
+	f.Add([]byte(`{}`))
+	f.Add([]byte(``))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _ = UnmarshalPayload(data)
+	})
+}
+
+func FuzzValidateIgnorePaths(f *testing.F) {
+	f.Add("cache/tmp")
+	f.Add("/absolute/path")
+	f.Add("../escape")
+	f.Add("glob*pattern")
+	f.Add("path\\backslash")
+	f.Add("")
+
+	f.Fuzz(func(t *testing.T, path string) {
+		_ = validateIgnorePaths([]string{path})
+	})
+}
+
 func TestUnmarshalPayload_DuplicateResourceNamesRejected(t *testing.T) {
 	payload := map[string]interface{}{
 		"_type":         "https://in-toto.io/Statement/v1",

--- a/pkg/oci/manifest_test.go
+++ b/pkg/oci/manifest_test.go
@@ -549,3 +549,40 @@ func TestCompareManifests(t *testing.T) {
 		t.Error("CompareManifests() expected error for different manifests, got nil")
 	}
 }
+
+func FuzzParseManifest(f *testing.F) {
+	f.Add([]byte(`{"schemaVersion":2,"config":{"digest":"sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","size":0},"layers":[{"digest":"sha256:abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234","size":100,"annotations":{"org.opencontainers.image.title":"model.bin"}}]}`))
+	f.Add([]byte(`{}`))
+	f.Add([]byte(``))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		m, err := ParseManifest(data)
+		if err != nil {
+			return
+		}
+		_ = m.Validate()
+	})
+}
+
+func FuzzValidateDigestFormat(f *testing.F) {
+	f.Add("sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+	f.Add("sha512:abcdef")
+	f.Add("invalid")
+	f.Add(":")
+	f.Add("")
+
+	f.Fuzz(func(t *testing.T, digest string) {
+		_ = validateDigestFormat(digest)
+	})
+}
+
+func FuzzParseDigestString(f *testing.F) {
+	f.Add("sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+	f.Add("abcdef1234")
+	f.Add("")
+	f.Add(":")
+
+	f.Fuzz(func(t *testing.T, digest string) {
+		_, _ = parseDigestString(digest)
+	})
+}

--- a/pkg/verify/helpers_test.go
+++ b/pkg/verify/helpers_test.go
@@ -475,3 +475,25 @@ func TestGetTimestampFromBundle_MultipleTimestamps_SelectsEarliest(t *testing.T)
 		t.Errorf("expected earliest timestamp %v, got %v", earlierTime, got)
 	}
 }
+
+func FuzzLoadBundleWithCompat(f *testing.F) {
+	f.Add([]byte(`{"mediaType":"application/vnd.dev.sigstore.bundle.v0.3+json","verificationMaterial":{}}`))
+	f.Add([]byte(`{"verificationMaterial":{"publicKey":{"rawBytes":"dGVzdA==","keyDetails":"EC_SIGN_P256_SHA256"}}}`))
+	f.Add([]byte(`{}`))
+	f.Add([]byte(`[]`))
+	f.Add([]byte(``))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _ = loadBundleWithCompat(data)
+	})
+}
+
+func FuzzExtractCertChainFromJSON(f *testing.F) {
+	f.Add([]byte(`{"verificationMaterial":{"x509CertificateChain":{"certificates":[{"rawBytes":"dGVzdA=="}]}}}`))
+	f.Add([]byte(`{}`))
+	f.Add([]byte(``))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _ = extractCertChainFromJSON(data)
+	})
+}


### PR DESCRIPTION
## Summary

Add 9 Go native fuzz tests (`func FuzzXxx`) covering all functions that parse untrusted input:

### Tier 1 — Critical (raw untrusted bytes)
- `FuzzLoadBundleWithCompat` — bundle JSON with compat transforms
- `FuzzUnmarshalPayload` — DSSE payload JSON to manifest
- `FuzzExtractCertChainFromJSON` — x509 certificate chain extraction

### Tier 2 — High (structured untrusted data)
- `FuzzSerializationTypeFromArgs` — serialization parameter map parsing
- `FuzzParseShardName` — `"path:start:end"` shard identifier parsing
- `FuzzParseManifest` — OCI manifest JSON parsing + validation
- `FuzzValidateIgnorePaths` — spec §6.2.1 path validation

### Tier 3 — Medium (internal helpers)
- `FuzzValidateDigestFormat` — `"algo:hex"` digest validation
- `FuzzParseDigestString` — lenient digest string parsing

All 9 targets pass ~9M total executions with no panics found.

Fixes #191

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test ./...` — all existing tests pass
- [x] Each fuzz target run for 10s — all pass, no crashes